### PR TITLE
Add Venice API integration and Railway deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# OpenRouter API key — powers all text models in the model selector.
+# Get yours at: https://openrouter.ai/settings/keys
+OPENROUTER_API_KEY=sk-or-v1-...
+
+# Default model for the Kady orchestrator (routed via LiteLLM proxy).
+# Any model ID from models.json works, e.g.:
+#   openrouter/google/gemini-3.1-pro-preview   (default)
+#   venice/llama-3.3-70b                       (privacy-first via Venice)
+DEFAULT_AGENT_MODEL=openrouter/google/gemini-3.1-pro-preview
+
+# ── Venice AI (optional) ──────────────────────────────────────────────────────
+# Enables Venice models in the model selector AND Venice tools (image gen,
+# upscaling, TTS, embeddings). Get your key at: https://venice.ai/settings/api
+VENICE_API_KEY=
+
+# ── Parallel Search (optional) ────────────────────────────────────────────────
+# Enables web search and URL fetching for Kady.
+# Get your key at: https://parallel.ai
+PARALLEL_API_KEY=
+
+# ── Modal (optional) ──────────────────────────────────────────────────────────
+# Enables remote GPU compute via Modal for heavy scientific workloads.
+# Get credentials at: https://modal.com
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=
+
+# ── Railway deployment (set these in Railway's environment variables UI) ───────
+
+# Leave empty so Next.js uses relative URLs proxied through Next.js rewrites.
+# On Railway, the frontend and backend run in the same container.
+NEXT_PUBLIC_ADK_API_URL=
+
+# Internal URL of the FastAPI backend (used by Next.js server-side rewrites).
+# Do NOT change this unless you run backend on a different port.
+ADK_API_URL=http://localhost:8000
+
+# Set to 1 on first Railway deploy to download the scientific skills library.
+# After first boot you can set it back to 0 for faster restarts.
+DOWNLOAD_SKILLS=0
+
+# LiteLLM proxy settings (auto-configured, only change if you have port conflicts)
+LITELLM_PROXY_BASE=http://localhost:4000
+LITELLM_PROXY_KEY=sk-litellm-local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# ── Stage 1: Python dependency layer ─────────────────────────────────────────
+FROM python:3.13-slim AS python-deps
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+COPY pyproject.toml uv.lock* ./
+RUN uv sync --no-dev --frozen 2>/dev/null || uv sync --no-dev
+
+
+# ── Stage 2: Node / frontend build ───────────────────────────────────────────
+FROM node:20-slim AS frontend-build
+
+WORKDIR /app/web
+
+COPY web/package*.json ./
+RUN npm ci --silent
+
+COPY web/ ./
+COPY pyproject.toml ../pyproject.toml
+
+RUN npm run build
+
+
+# ── Stage 3: Final runtime image ──────────────────────────────────────────────
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Runtime system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install a specific LTS Node version for Gemini CLI compatibility
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+# Install Gemini CLI globally
+RUN npm install -g @google/gemini-cli --silent
+
+# Copy Python virtual env from build stage
+COPY --from=python-deps /app/.venv /app/.venv
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Copy application source
+COPY . .
+
+# Copy built Next.js app
+COPY --from=frontend-build /app/web/.next /app/web/.next
+COPY --from=frontend-build /app/web/node_modules /app/web/node_modules
+
+# Pre-create sandbox directories (skills downloaded at container start)
+RUN mkdir -p sandbox/user_data sandbox/.gemini/skills user_config
+
+# Expose the frontend port (Railway routes external traffic here)
+EXPOSE 3000
+
+ENV RAILWAY=1
+
+CMD ["bash", "start_railway.sh"]

--- a/kady_agent/agent.py
+++ b/kady_agent/agent.py
@@ -6,6 +6,13 @@ from google.adk.models.lite_llm import LiteLlm
 from .mcps import all_mcps
 
 from .tools.gemini_cli import delegate_task
+from .tools.venice import (
+    venice_generate_image,
+    venice_upscale_image,
+    venice_text_to_speech,
+    venice_embed,
+    venice_list_models,
+)
 from .utils import load_instructions
 
 load_dotenv()
@@ -13,6 +20,12 @@ load_dotenv()
 DEFAULT_MODEL = os.getenv("DEFAULT_AGENT_MODEL")
 EXTRA_HEADERS = {"X-Title": "Kady", "HTTP-Referer": "https://www.k-dense.ai"}
 PARALLEL_API_KEY = os.getenv("PARALLEL_API_KEY")
+VENICE_API_KEY = os.getenv("VENICE_API_KEY")
+
+# Route all model calls through the local LiteLLM proxy so both OpenRouter
+# and Venice models are handled by a single routing layer.
+LITELLM_PROXY_BASE = os.getenv("LITELLM_PROXY_BASE", "http://localhost:4000")
+LITELLM_PROXY_KEY = os.getenv("LITELLM_PROXY_KEY", "sk-litellm-local")
 
 
 def _override_model(callback_context, llm_request):
@@ -22,15 +35,29 @@ def _override_model(callback_context, llm_request):
     return None
 
 
+# Venice tools are always registered; they fail gracefully when VENICE_API_KEY
+# is absent so the agent can report the missing key to the user.
+_venice_tools = [
+    venice_generate_image,
+    venice_upscale_image,
+    venice_text_to_speech,
+    venice_embed,
+    venice_list_models,
+]
+
 root_agent = LlmAgent(
     name="MainAgent",
     model=LiteLlm(
         model=DEFAULT_MODEL,
+        # Route through the local LiteLLM proxy so Venice models and
+        # OpenRouter models both resolve without per-model configuration here.
+        api_base=LITELLM_PROXY_BASE,
+        api_key=LITELLM_PROXY_KEY,
         extra_headers=EXTRA_HEADERS,
     ),
     description="The main agent that makes sure the user's request is successfully fulfilled",
     instruction=load_instructions("main_agent"),
-    tools=[delegate_task] + all_mcps,
+    tools=[delegate_task] + _venice_tools + all_mcps,
     output_key="final_output",
     before_model_callback=_override_model,
 )

--- a/kady_agent/instructions/main_agent.md
+++ b/kady_agent/instructions/main_agent.md
@@ -31,6 +31,22 @@ Choose the lightest reliable path:
 - Prefer Docling for document conversion, text extraction, and markdown export.
 - For reports, papers, literature reviews, or other structured prose, instruct the expert to use the `writing` skill.
 
+## Venice AI tools
+
+You have direct access to Venice AI's API. Use these tools without delegating when the request is purely creative media or embedding:
+
+| Tool | When to use |
+|------|-------------|
+| `venice_generate_image` | User asks to generate, create, or draw an image or illustration. Pick model based on style: `fluently-xl` (photorealistic), `pony-realism` (anime/art), `venice-sd35` (Stable Diffusion 3.5). Set `style_preset` when the user specifies a visual style. |
+| `venice_upscale_image` | User asks to upscale, enhance, or increase resolution of an existing image in the sandbox. |
+| `venice_text_to_speech` | User asks to narrate, read aloud, or produce audio from text. Choose voice based on context: `af_sky`/`af_bella`/`af_nicole`/`af_sarah` (female), `am_adam`/`am_michael`/`am_echo` (male). |
+| `venice_embed` | User needs vector embeddings for semantic search, clustering, or similarity — embed the texts directly. |
+| `venice_list_models` | User asks what Venice models are available. Filter by `model_type`: `'text'`, `'image'`, `'tts'`, `'embedding'`, or `'all'`. |
+
+**Privacy note:** When the user explicitly wants privacy-first inference (no logging, no training), recommend selecting a Venice model from the model selector. Venice models appear with a purple "Venice" label.
+
+**Error handling:** If a Venice tool returns an error about a missing API key, tell the user to add `VENICE_API_KEY=...` to `kady_agent/.env` and restart.
+
 ## After tool use
 
 - Synthesize results in your own words. Do not dump raw tool output.

--- a/kady_agent/tools/__init__.py
+++ b/kady_agent/tools/__init__.py
@@ -1,3 +1,17 @@
 from .gemini_cli import delegate_task
+from .venice import (
+    venice_generate_image,
+    venice_upscale_image,
+    venice_text_to_speech,
+    venice_embed,
+    venice_list_models,
+)
 
-__all__ = ["delegate_task"]
+__all__ = [
+    "delegate_task",
+    "venice_generate_image",
+    "venice_upscale_image",
+    "venice_text_to_speech",
+    "venice_embed",
+    "venice_list_models",
+]

--- a/kady_agent/tools/venice.py
+++ b/kady_agent/tools/venice.py
@@ -1,0 +1,342 @@
+"""Venice AI tools — image generation, image upscaling, and text-to-speech.
+
+These tools call the Venice API directly and save outputs to the sandbox so
+they appear in the file browser and can be referenced in subsequent tasks.
+
+Requires VENICE_API_KEY to be set in kady_agent/.env.
+Venice API docs: https://docs.venice.ai/api-reference/
+"""
+
+import base64
+import os
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+VENICE_API_BASE = "https://api.venice.ai/api/v1"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SANDBOX_USER_DATA = _REPO_ROOT / "sandbox" / "user_data"
+
+
+def _headers() -> dict[str, str]:
+    key = os.environ.get("VENICE_API_KEY", "")
+    if not key:
+        raise ValueError(
+            "VENICE_API_KEY is not set. Add it to kady_agent/.env to use Venice tools."
+        )
+    return {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _ensure_user_data() -> Path:
+    SANDBOX_USER_DATA.mkdir(parents=True, exist_ok=True)
+    return SANDBOX_USER_DATA
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+# ── Image generation ──────────────────────────────────────────────────────────
+
+async def venice_generate_image(
+    prompt: str,
+    model: str = "fluently-xl",
+    width: int = 1024,
+    height: int = 1024,
+    steps: int = 25,
+    style_preset: str | None = None,
+    negative_prompt: str | None = None,
+    safe_mode: bool = False,
+    enhance_prompt: bool = True,
+    filename: str | None = None,
+) -> dict:
+    """Generate an image using Venice AI's image generation API and save it to the sandbox.
+
+    Args:
+        prompt: Text description of the image to generate.
+        model: Venice image model. Options:
+            'fluently-xl' (photorealism, default),
+            'pony-realism' (anime/illustration),
+            'venice-sd35' (Stable Diffusion 3.5),
+            'hidream-i1-full' (high detail).
+        width: Image width in pixels (default 1024). Common: 512, 768, 1024, 1280, 1536.
+        height: Image height in pixels (default 1024). Common: 512, 768, 1024, 1280, 1536.
+        steps: Diffusion steps, higher = more detail but slower (default 25, range 1–50).
+        style_preset: Optional style preset. Options: 'ANIME', 'CINEMATIC', 'DIGITAL_ART',
+            'ENHANCE', 'FANTASY_ART', 'ISOMETRIC', 'LINE_ART', 'LOW_POLY',
+            'NEON_PUNK', 'ORIGAMI', 'PHOTOGRAPHIC', 'PIXEL_ART', 'TILE_TEXTURE'.
+        negative_prompt: What to exclude from the image (e.g. 'blurry, low quality').
+        safe_mode: Whether to apply content safety filtering (default False).
+        enhance_prompt: Whether Venice should auto-enhance the prompt (default True).
+        filename: Optional output filename without extension (saved to sandbox/user_data/).
+
+    Returns:
+        dict with 'file_path', 'filename', and 'message'.
+    """
+    venice_params: dict = {
+        "safe_mode": safe_mode,
+        "enhance_prompt": enhance_prompt,
+    }
+    if style_preset:
+        venice_params["style_preset"] = style_preset
+    if negative_prompt:
+        venice_params["negative_prompt"] = negative_prompt
+
+    payload: dict = {
+        "model": model,
+        "prompt": prompt,
+        "n": 1,
+        "size": f"{width}x{height}",
+        "response_format": "b64_json",
+        "venice_parameters": {
+            **venice_params,
+            "steps": steps,
+        },
+    }
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{VENICE_API_BASE}/images/generations",
+            headers=_headers(),
+            json=payload,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Venice image generation failed ({response.status_code}): {response.text}"
+            )
+        data = response.json()
+
+    b64 = data["data"][0].get("b64_json")
+    if not b64:
+        raise RuntimeError("Venice API did not return base64 image data.")
+
+    out_dir = _ensure_user_data()
+    base = filename or f"venice_image_{_timestamp()}"
+    out_path = out_dir / f"{base}.png"
+    out_path.write_bytes(base64.b64decode(b64))
+
+    rel = f"sandbox/user_data/{out_path.name}"
+    return {
+        "file_path": rel,
+        "filename": out_path.name,
+        "message": f"Image generated and saved to {rel}",
+    }
+
+
+# ── Image upscaling ───────────────────────────────────────────────────────────
+
+async def venice_upscale_image(
+    image_path: str,
+    scale: int = 2,
+    filename: str | None = None,
+) -> dict:
+    """Upscale an image using Venice AI's upscaling API.
+
+    Args:
+        image_path: Path to the image file, relative to the repo root
+            (e.g. 'sandbox/user_data/image.png') or an absolute path.
+        scale: Upscale factor (2 or 4, default 2).
+        filename: Optional output filename without extension.
+
+    Returns:
+        dict with 'file_path', 'filename', and 'message'.
+    """
+    src = Path(image_path)
+    if not src.is_absolute():
+        src = _REPO_ROOT / src
+    if not src.exists():
+        raise FileNotFoundError(f"Image not found: {src}")
+
+    image_bytes = src.read_bytes()
+    mime = "image/png" if src.suffix.lower() == ".png" else "image/jpeg"
+
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('VENICE_API_KEY', '')}",
+    }
+    if not os.environ.get("VENICE_API_KEY"):
+        raise ValueError("VENICE_API_KEY is not set.")
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{VENICE_API_BASE}/images/upscale",
+            headers=headers,
+            files={"image": (src.name, image_bytes, mime)},
+            data={"scale": str(scale)},
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Venice image upscaling failed ({response.status_code}): {response.text}"
+            )
+        result_bytes = response.content
+
+    out_dir = _ensure_user_data()
+    base = filename or f"{src.stem}_upscaled_{scale}x_{_timestamp()}"
+    ext = src.suffix or ".png"
+    out_path = out_dir / f"{base}{ext}"
+    out_path.write_bytes(result_bytes)
+
+    rel = f"sandbox/user_data/{out_path.name}"
+    return {
+        "file_path": rel,
+        "filename": out_path.name,
+        "message": f"Image upscaled {scale}x and saved to {rel}",
+    }
+
+
+# ── Text to speech ────────────────────────────────────────────────────────────
+
+async def venice_text_to_speech(
+    text: str,
+    voice: str = "af_sky",
+    model: str = "tts-kokoro",
+    speed: float = 1.0,
+    response_format: str = "mp3",
+    filename: str | None = None,
+) -> dict:
+    """Convert text to speech using Venice AI's TTS API and save the audio to the sandbox.
+
+    Args:
+        text: The text to convert to speech (max ~4000 characters recommended).
+        voice: Voice ID. Venice voices: 'af_sky' (warm female), 'af_bella' (expressive female),
+            'af_nicole' (soft female), 'af_sarah', 'af_nova', 'am_adam' (male),
+            'am_michael', 'am_echo'. OpenAI-compatible: 'alloy', 'echo', 'fable',
+            'onyx', 'nova', 'shimmer'.
+        model: TTS model. Use 'tts-kokoro' (default, Venice-native, high quality).
+        speed: Speech speed multiplier (0.25–4.0, default 1.0).
+        response_format: Audio format: 'mp3' (default), 'opus', 'aac', 'flac', 'wav', 'pcm'.
+        filename: Optional output filename without extension.
+
+    Returns:
+        dict with 'file_path', 'filename', and 'message'.
+    """
+    payload = {
+        "model": model,
+        "input": text,
+        "voice": voice,
+        "speed": speed,
+        "response_format": response_format,
+    }
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{VENICE_API_BASE}/audio/speech",
+            headers=_headers(),
+            json=payload,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Venice TTS failed ({response.status_code}): {response.text}"
+            )
+        audio_bytes = response.content
+
+    out_dir = _ensure_user_data()
+    base = filename or f"venice_speech_{_timestamp()}"
+    out_path = out_dir / f"{base}.{response_format}"
+    out_path.write_bytes(audio_bytes)
+
+    rel = f"sandbox/user_data/{out_path.name}"
+    return {
+        "file_path": rel,
+        "filename": out_path.name,
+        "message": f"Audio saved to {rel}",
+    }
+
+
+# ── Embeddings ────────────────────────────────────────────────────────────────
+
+async def venice_embed(
+    texts: list[str],
+    model: str = "text-embedding-bge-m3",
+) -> dict:
+    """Generate vector embeddings using Venice AI's embeddings API.
+
+    Args:
+        texts: List of strings to embed (max 2048 tokens each).
+        model: Embedding model. Use 'text-embedding-bge-m3' (default, multilingual,
+            1024 dimensions) or 'text-embedding-nomic-embed-text-v1.5' (768 dims).
+
+    Returns:
+        dict with 'embeddings' (list of float vectors), 'model', and 'usage'.
+    """
+    payload = {
+        "model": model,
+        "input": texts,
+    }
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            f"{VENICE_API_BASE}/embeddings",
+            headers=_headers(),
+            json=payload,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Venice embeddings failed ({response.status_code}): {response.text}"
+            )
+        data = response.json()
+
+    embeddings = [item["embedding"] for item in data["data"]]
+    return {
+        "embeddings": embeddings,
+        "model": data.get("model", model),
+        "usage": data.get("usage", {}),
+        "dimensions": len(embeddings[0]) if embeddings else 0,
+    }
+
+
+# ── List Venice models ────────────────────────────────────────────────────────
+
+async def venice_list_models(
+    model_type: str = "text",
+) -> dict:
+    """List available models on Venice AI.
+
+    Args:
+        model_type: Filter by type: 'text' (LLMs), 'image' (image generation),
+            'embedding', 'tts', or 'all' (no filter).
+
+    Returns:
+        dict with 'models' list and 'count'.
+    """
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            f"{VENICE_API_BASE}/models",
+            headers=_headers(),
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Venice models list failed ({response.status_code}): {response.text}"
+            )
+        data = response.json()
+
+    all_models = data.get("data", [])
+
+    if model_type != "all":
+        type_map = {
+            "text": ["text"],
+            "image": ["image"],
+            "embedding": ["embedding", "embeddings"],
+            "tts": ["tts", "audio"],
+        }
+        allowed = type_map.get(model_type, [model_type])
+        all_models = [
+            m for m in all_models
+            if any(t in (m.get("type", "") or m.get("object", "")).lower() for t in allowed)
+            or any(t in m.get("id", "").lower() for t in allowed)
+        ]
+
+    model_summaries = [
+        {
+            "id": m.get("id"),
+            "type": m.get("type") or m.get("object"),
+            "context_length": m.get("context_length"),
+            "max_tokens": m.get("max_tokens"),
+        }
+        for m in all_models
+    ]
+
+    return {"models": model_summaries, "count": len(model_summaries)}

--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -13,8 +13,15 @@
     HTTP-Referer: "https://www.k-dense.ai"
     X-Title: "Kady-Expert"
 
+.venice_shared: &venice_shared
+  api_base: https://api.venice.ai/api/v1
+  api_key: os.environ/VENICE_API_KEY
+  custom_llm_provider: openai
+  timeout: 600
+  stream_timeout: 600
+
 model_list:
-  # ── Gemini models ──
+  # ── Gemini models (via OpenRouter, used by Gemini CLI experts) ──
   - model_name: gemini-3.1-pro-preview
     litellm_params:
       <<: *openrouter_shared
@@ -27,6 +34,48 @@ model_list:
     litellm_params:
       <<: *openrouter_shared
       model: google/gemini-3.1-flash-lite-preview
+
+  # ── Venice AI models (privacy-first, uncensored options) ──
+  - model_name: venice/llama-3.3-70b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/llama-3.3-70b
+  - model_name: venice/mistral-31-24b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/mistral-31-24b
+  - model_name: venice/deepseek-r1
+    litellm_params:
+      <<: *venice_shared
+      model: openai/deepseek-ai/DeepSeek-R1
+  - model_name: venice/qwen3-235b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/qwen3-235b-a22b-instruct-2507
+  - model_name: venice/qwen3-4b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/qwen3-4b
+  - model_name: venice/llama-3.2-3b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/llama-3.2-3b
+  - model_name: venice/venice-uncensored
+    litellm_params:
+      <<: *venice_shared
+      model: openai/venice-uncensored
+  - model_name: venice/qwen3-coder-480b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/qwen3-coder-480b-a35b-instruct
+  - model_name: venice/gemma-3-27b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/google-gemma-3-27b-it
+  - model_name: venice/llama-3.1-405b
+    litellm_params:
+      <<: *venice_shared
+      model: openai/hermes-3-llama-3.1-405b
 
 router_settings:
   # Retry failed routing attempts (helps flaky upstream / transient errors)
@@ -42,6 +91,13 @@ router_settings:
     "gemini-2.5-flash": "gemini-3.1-pro-preview"
     "gemini-2.5-flash-lite": "gemini-3-flash-preview"
     "gemini-3-pro-preview": "gemini-3.1-pro-preview"
+    # Venice model aliases for ADK customtools suffix
+    "venice/llama-3.3-70b-customtools": "venice/llama-3.3-70b"
+    "venice/mistral-31-24b-customtools": "venice/mistral-31-24b"
+    "venice/deepseek-r1-customtools": "venice/deepseek-r1"
+    "venice/qwen3-235b-customtools": "venice/qwen3-235b"
+    "venice/venice-uncensored-customtools": "venice/venice-uncensored"
+    "venice/qwen3-coder-480b-customtools": "venice/qwen3-coder-480b"
 
 general_settings:
   master_key: sk-litellm-local

--- a/prep_sandbox.py
+++ b/prep_sandbox.py
@@ -46,4 +46,7 @@ if not os.path.isfile(SANDBOX_PYPROJECT):
 print("Syncing sandbox Python environment...")
 subprocess.run(["uv", "sync"], check=True, cwd=SANDBOX_DIR)
 
-download_scientific_skills(target_dir="sandbox/.gemini/skills")
+if os.environ.get("SKIP_SKILL_DOWNLOAD", "").lower() not in ("1", "true", "yes"):
+    download_scientific_skills(target_dir="sandbox/.gemini/skills")
+else:
+    print("Skipping scientific skills download (SKIP_SKILL_DOWNLOAD is set).")

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,11 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+numReplicas = 1
+sleepApplication = false
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 10
+# Railway exposes $PORT to the container; our start_railway.sh passes it to Next.js
+# healthcheckPath = "/health"  # uncomment if you add a Next.js /health route

--- a/server.py
+++ b/server.py
@@ -19,10 +19,16 @@ from kady_agent.gemini_settings import (
     write_merged_settings,
 )
 
+# In Railway the Next.js server proxies all API calls, so the browser never
+# talks directly to FastAPI. For local dev we still allow localhost:3000.
+# Set CORS_ORIGINS env var to a comma-separated list to override.
+_cors_env = os.environ.get("CORS_ORIGINS", "").strip()
+_allow_origins = _cors_env.split(",") if _cors_env else ["http://localhost:3000"]
+
 app = get_fast_api_app(
     agents_dir=".",
     web=False,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=_allow_origins,
     auto_create_session=True,
 )
 
@@ -48,8 +54,10 @@ async def config():
     """Expose non-secret feature flags to the frontend."""
     modal_id = os.environ.get("MODAL_TOKEN_ID", "").strip()
     modal_secret = os.environ.get("MODAL_TOKEN_SECRET", "").strip()
+    venice_key = os.environ.get("VENICE_API_KEY", "").strip()
     return {
         "modal_configured": bool(modal_id and modal_secret),
+        "venice_configured": bool(venice_key),
     }
 
 

--- a/start_railway.sh
+++ b/start_railway.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Railway deployment startup script.
+# All three services (LiteLLM proxy, FastAPI backend, Next.js frontend) run
+# in the same container. Railway routes external traffic to $PORT (Next.js).
+# The backend (8000) and proxy (4000) are internal only.
+set -e
+
+cd "$(dirname "$0")"
+
+export PATH="/root/.local/bin:/app/.venv/bin:$PATH"
+
+echo "============================================"
+echo "  Kady — Railway startup"
+echo "============================================"
+
+# ── Sandbox preparation ───────────────────────────────────────────────────────
+# Skip the slow scientific-skills download on Railway to keep startup fast.
+# Set DOWNLOAD_SKILLS=1 in Railway env vars to enable it on first boot.
+echo "Preparing sandbox..."
+if [ "${DOWNLOAD_SKILLS:-0}" = "1" ]; then
+    python prep_sandbox.py
+else
+    SKIP_SKILL_DOWNLOAD=1 python prep_sandbox.py
+fi
+
+echo
+
+# ── LiteLLM proxy ─────────────────────────────────────────────────────────────
+echo "  → LiteLLM proxy on port 4000"
+litellm --config litellm_config.yaml --port 4000 &
+LITELLM_PID=$!
+sleep 3
+
+# ── FastAPI backend ───────────────────────────────────────────────────────────
+echo "  → Backend on port 8000"
+uvicorn server:app --host 0.0.0.0 --port 8000 &
+BACKEND_PID=$!
+
+# ── Next.js frontend ──────────────────────────────────────────────────────────
+# Railway assigns $PORT; default to 3000 for local Docker runs.
+FRONTEND_PORT="${PORT:-3000}"
+echo "  → Frontend on port ${FRONTEND_PORT}"
+cd web && PORT="${FRONTEND_PORT}" npm start &
+FRONTEND_PID=$!
+
+echo
+echo "============================================"
+echo "  All services running (Railway mode)"
+echo "  Frontend: http://localhost:${FRONTEND_PORT}"
+echo "  Backend:  http://localhost:8000"
+echo "  Proxy:    http://localhost:4000"
+echo "============================================"
+
+trap "kill $LITELLM_PID $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit 0" INT TERM
+wait

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -12,10 +12,28 @@ function readVersionFromPyproject(): string {
   }
 }
 
+// Internal backend URL used by Next.js server-side rewrites.
+// On Railway (and local Docker) both services run in the same container.
+const ADK_API_URL = process.env.ADK_API_URL ?? "http://localhost:8000";
+
 const nextConfig: NextConfig = {
   devIndicators: false,
   env: {
     NEXT_PUBLIC_APP_VERSION: readVersionFromPyproject(),
+  },
+  // Proxy all backend API paths through Next.js so the browser only ever
+  // talks to one origin. This enables Railway (and any reverse-proxy) to
+  // work without extra CORS configuration.
+  async rewrites() {
+    return [
+      { source: "/run_sse", destination: `${ADK_API_URL}/run_sse` },
+      { source: "/apps/:path*", destination: `${ADK_API_URL}/apps/:path*` },
+      { source: "/health", destination: `${ADK_API_URL}/health` },
+      { source: "/config", destination: `${ADK_API_URL}/config` },
+      { source: "/skills", destination: `${ADK_API_URL}/skills` },
+      { source: "/sandbox/:path*", destination: `${ADK_API_URL}/sandbox/:path*` },
+      { source: "/settings/:path*", destination: `${ADK_API_URL}/settings/:path*` },
+    ];
   },
 };
 

--- a/web/src/components/model-selector.tsx
+++ b/web/src/components/model-selector.tsx
@@ -36,6 +36,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   DeepSeek:  "text-cyan-600 dark:text-cyan-400",
   xAI:       "text-rose-600 dark:text-rose-400",
   Meta:      "text-indigo-600 dark:text-indigo-400",
+  Venice:    "text-purple-600 dark:text-purple-400",
 };
 
 function TierDot({ tier }: { tier: string }) {

--- a/web/src/data/models.json
+++ b/web/src/data/models.json
@@ -376,5 +376,135 @@
     },
     "modality": "text->text",
     "description": "MiniMax-M2.5 is a SOTA large language model designed for real-world productivity. Trained in a diverse range of complex real-world digital working environments, M2.5 builds upon the coding expertise of M2.1 to extend into general office work, reaching fluency in generating and operating Word, Excel, and Powerpoint files, context switching between diverse software environments, and working across different agent and human teams. Scoring 80.2% on SWE-Bench Verified, 51.3% on Multi-SWE-Bench, and 76.3% on BrowseComp, M2.5 is also more token efficient than previous generations, having been trained to optimize its actions and output through planning."
+  },
+  {
+    "id": "venice/deepseek-r1",
+    "label": "DeepSeek R1 (Venice)",
+    "provider": "Venice",
+    "tier": "high",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 3.0,
+      "completion": 9.0
+    },
+    "modality": "text->text",
+    "description": "DeepSeek R1 hosted on Venice AI's privacy-preserving infrastructure. Venice does not log or train on your conversations. Supports extended chain-of-thought reasoning for complex analytical, mathematical, and coding tasks. Ideal when you need powerful reasoning with full data privacy."
+  },
+  {
+    "id": "venice/qwen3-235b",
+    "label": "Qwen3 235B (Venice)",
+    "provider": "Venice",
+    "tier": "high",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 2.0,
+      "completion": 6.0
+    },
+    "modality": "text->text",
+    "description": "Qwen3 235B MoE instruction-tuned model hosted on Venice AI. A top-tier open-weight model with strong multilingual reasoning, coding, and instruction-following capabilities. Served with Venice's privacy-first, no-logging inference."
+  },
+  {
+    "id": "venice/qwen3-coder-480b",
+    "label": "Qwen3 Coder 480B (Venice)",
+    "provider": "Venice",
+    "tier": "high",
+    "context_length": 262144,
+    "pricing": {
+      "prompt": 2.5,
+      "completion": 7.5
+    },
+    "modality": "text->text",
+    "description": "Qwen3 Coder 480B is a massive MoE coding model hosted on Venice AI. Optimized for long-horizon agentic coding tasks, complex tool use, and autonomous code generation. Features a 256K context window and Venice's private inference guarantees."
+  },
+  {
+    "id": "venice/llama-3.3-70b",
+    "label": "Llama 3.3 70B (Venice)",
+    "provider": "Venice",
+    "tier": "mid",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 0.18,
+      "completion": 0.72
+    },
+    "modality": "text->text",
+    "description": "Meta's Llama 3.3 70B hosted on Venice AI for private, uncensored inference. Excellent all-around performance for reasoning, coding, and creative tasks. Venice guarantees no conversation logging or training on your data."
+  },
+  {
+    "id": "venice/llama-3.1-405b",
+    "label": "Llama 3.1 405B Hermes (Venice)",
+    "provider": "Venice",
+    "tier": "mid",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 0.8,
+      "completion": 2.4
+    },
+    "modality": "text->text",
+    "description": "Hermes 3 fine-tuned on Llama 3.1 405B, hosted on Venice AI. A top-tier open-weight model excelling at agentic tasks, function calling, and complex reasoning. Venice's privacy-first infrastructure ensures no data retention."
+  },
+  {
+    "id": "venice/gemma-3-27b",
+    "label": "Gemma 3 27B (Venice)",
+    "provider": "Venice",
+    "tier": "mid",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 0.2,
+      "completion": 0.8
+    },
+    "modality": "text->text",
+    "description": "Google's Gemma 3 27B instruction-tuned model hosted on Venice AI. Strong multimodal-trained backbone with excellent text performance for its size. Served with Venice's privacy-first, no-logging infrastructure."
+  },
+  {
+    "id": "venice/mistral-31-24b",
+    "label": "Mistral 3.1 24B (Venice)",
+    "provider": "Venice",
+    "tier": "budget",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 0.12,
+      "completion": 0.48
+    },
+    "modality": "text->text",
+    "description": "Mistral 3.1 24B hosted on Venice AI. A highly capable mid-size model with strong instruction following, multilingual support, and efficient inference. Venice's private compute ensures your conversations remain confidential."
+  },
+  {
+    "id": "venice/venice-uncensored",
+    "label": "Venice Uncensored",
+    "provider": "Venice",
+    "tier": "budget",
+    "context_length": 8192,
+    "pricing": {
+      "prompt": 0.05,
+      "completion": 0.2
+    },
+    "modality": "text->text",
+    "description": "Venice's own uncensored model with no content restrictions beyond illegality. Designed for creative writing, roleplay, and research that mainstream models decline. Operates entirely on Venice's private, no-log infrastructure."
+  },
+  {
+    "id": "venice/qwen3-4b",
+    "label": "Qwen3 4B (Venice)",
+    "provider": "Venice",
+    "tier": "budget",
+    "context_length": 32768,
+    "pricing": {
+      "prompt": 0.03,
+      "completion": 0.12
+    },
+    "modality": "text->text",
+    "description": "Qwen3 4B is a compact but capable model hosted on Venice AI. Ideal for fast, lightweight tasks where privacy matters. Venice's no-log policy applies to all inference, even at this budget tier."
+  },
+  {
+    "id": "venice/llama-3.2-3b",
+    "label": "Llama 3.2 3B (Venice)",
+    "provider": "Venice",
+    "tier": "budget",
+    "context_length": 131072,
+    "pricing": {
+      "prompt": 0.02,
+      "completion": 0.08
+    },
+    "modality": "text->text",
+    "description": "Meta's Llama 3.2 3B hosted on Venice AI. The most cost-effective option for simple tasks, summarization, and classification. Venice's privacy infrastructure ensures zero data retention even for high-volume, low-cost inference."
   }
 ]

--- a/web/src/lib/use-config.ts
+++ b/web/src/lib/use-config.ts
@@ -6,9 +6,10 @@ const API_BASE = process.env.NEXT_PUBLIC_ADK_API_URL ?? "http://localhost:8000";
 
 export interface AppConfig {
   modalConfigured: boolean;
+  veniceConfigured: boolean;
 }
 
-const DEFAULT_CONFIG: AppConfig = { modalConfigured: false };
+const DEFAULT_CONFIG: AppConfig = { modalConfigured: false, veniceConfigured: false };
 
 export function useConfig(): AppConfig {
   const [config, setConfig] = useState<AppConfig>(DEFAULT_CONFIG);
@@ -19,7 +20,10 @@ export function useConfig(): AppConfig {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (!cancelled && data) {
-          setConfig({ modalConfigured: !!data.modal_configured });
+          setConfig({
+            modalConfigured: !!data.modal_configured,
+            veniceConfigured: !!data.venice_configured,
+          });
         }
       })
       .catch(() => {});


### PR DESCRIPTION
Venice API:
- Add 10 Venice text models to models.json (DeepSeek R1, Qwen3 235B, Llama 3.3 70B, Mistral 3.1 24B, Venice Uncensored, and more) with purple provider branding
- Add venice_shared config to litellm_config.yaml routing venice/* model names to Venice API (https://api.venice.ai/api/v1) with customtools aliases
- Create kady_agent/tools/venice.py with five tools available directly to Kady: venice_generate_image (fluently-xl, pony-realism, venice-sd35), venice_upscale_image, venice_text_to_speech (tts-kokoro, multiple voices), venice_embed (BGE-M3), venice_list_models
- Route Kady agent through local LiteLLM proxy (api_base=localhost:4000) so both OpenRouter and Venice models resolve from a single routing layer
- Add venice_configured flag to /config endpoint and useConfig hook
- Update main_agent.md with Venice tool usage instructions and privacy guidance

Railway deployment:
- Dockerfile: multi-stage build (python-deps → frontend-build → runtime), installs uv, Node 20, Gemini CLI; pre-creates sandbox dirs
- railway.toml: Dockerfile builder, on_failure restart policy
- start_railway.sh: production startup (litellm + uvicorn + next start), respects $PORT from Railway, skips skill download by default
- next.config.ts: rewrites all backend paths (/run_sse, /apps/*, /config, /sandbox/*, etc.) to ADK_API_URL so browser uses single Railway origin
- server.py: configurable CORS_ORIGINS env var for Railway deployments
- prep_sandbox.py: SKIP_SKILL_DOWNLOAD env var for faster cloud restarts
- .env.example: full template with OpenRouter, Venice, Parallel, Modal keys

https://claude.ai/code/session_01Rim3yotwKKkAipsrmR5o4S