### PR TITLE
feat: add Tavily Search MCP as parallel search option alongside Exa

### DIFF
--- a/kady_agent/env.example
+++ b/kady_agent/env.example
@@ -33,6 +33,9 @@ OLLAMA_BASE_URL=http://localhost:11434
 # Exa Search (get your key at https://dashboard.exa.ai/api-keys)
 EXA_API_KEY=
 
+# Tavily Search (get your key at https://app.tavily.com)
+TAVILY_API_KEY=
+
 # Parallel Search
 PARALLEL_API_KEY=
 

--- a/kady_agent/instructions/main_agent.md
+++ b/kady_agent/instructions/main_agent.md
@@ -32,7 +32,7 @@ You do **NOT** have the ability to activate or execute skills. Skills are capabi
 - In `prompt`, pass the user's request, the expert's role/objective/constraints, relevant context, file paths, URLs, and explicit success criteria.
 - Do not prescribe implementation approaches, libraries, or fallback methods unless the user explicitly requires them.
 - **Skills passthrough (MANDATORY):** If the user's message names specific skills (e.g. "use the parallel-web skill" or "use the skills: 'writing', 'literature-review'"), you MUST include an explicit instruction in the delegate prompt telling the expert to activate those skills. Use the format: `"You MUST activate and follow these skills: 'skill-name-1', 'skill-name-2'."` Do not paraphrase, omit, reorder, or summarize the skill list. The expert relies on exact names to activate the correct skills.
-- **Proactive skill matching:** Even when the user does not name a skill, consult the skill reference table and identify skills that match the task. Include them in the delegate prompt the same way: `"You should activate and follow these skills: 'skill-name'."` For example, if the user asks to "search the web for X", include whichever web-search skill matches the enabled MCP (`exa-search` for Exa Search MCP, `parallel-web` for Parallel Search MCP); if they ask for a "literature review", include `literature-review` and `writing`.
+- **Proactive skill matching:** Even when the user does not name a skill, consult the skill reference table and identify skills that match the task. Include them in the delegate prompt the same way: `"You should activate and follow these skills: 'skill-name'."` For example, if the user asks to "search the web for X", include whichever web-search skill matches the enabled MCP (`exa-search` for Exa Search MCP, `tavily-search` for Tavily Search MCP, `parallel-web` for Parallel Search MCP); if they ask for a "literature review", include `literature-review` and `writing`.
 - **Modal compute passthrough (MANDATORY):** If the user's prompt requests specific compute infrastructure and mentions **Modal** (e.g. "run this on Modal", "use Modal GPUs", "deploy on Modal"), you MUST:
   1. Include the compute requirement explicitly in the `delegate_task` prompt.
   2. State that the expert **MUST activate and follow the `modal` skill** before writing or running any Modal-related code.
@@ -40,7 +40,7 @@ You do **NOT** have the ability to activate or execute skills. Skills are capabi
 
 ## Tool preferences
 
-- Prefer Exa Search MCP or Parallel Search MCP for open-web search and URL content retrieval — whichever is available. Both expose MCP tools for search and content fetch; the user's `.env` determines which one (or both) are enabled.
+- Prefer Exa Search MCP, Tavily Search MCP, or Parallel Search MCP for open-web search and URL content retrieval — whichever is available. All three expose MCP tools for search and content fetch; the user's `.env` determines which ones are enabled.
 - Prefer Docling for document conversion, text extraction, and markdown export.
 - Users may install custom MCP tools (e.g. memory/knowledge-graph, filesystem, databases, specialized APIs) via the Settings panel. These tools appear alongside the built-in ones — use them directly whenever the request matches their capabilities instead of routing through `delegate_task`.
 - For reports, papers, literature reviews, or other structured prose, instruct the expert to use the `writing` skill.

--- a/kady_agent/mcp.py
+++ b/kady_agent/mcp.py
@@ -896,6 +896,21 @@ if os.getenv("EXA_API_KEY"):
     )
     all_mcps.append(exa_search_mcp)
 
+if os.getenv("TAVILY_API_KEY"):
+    tavily_search_mcp = ResilientMcpToolset(
+        McpToolset(
+            connection_params=StreamableHTTPConnectionParams(
+                url="https://mcp.tavily.com/mcp",
+                headers={
+                    "Authorization": f"Bearer {os.getenv('TAVILY_API_KEY')}",
+                },
+                timeout=600,
+            ),
+        ),
+        label="Tavily Search MCP",
+    )
+    all_mcps.append(tavily_search_mcp)
+
 if os.getenv("PARALLEL_API_KEY"):
     parallel_search_mcp = ResilientMcpToolset(
         McpToolset(


### PR DESCRIPTION
## Summary

Adds Tavily Search MCP as a configurable web-search option alongside the existing Exa Search and Parallel Search MCPs. When `TAVILY_API_KEY` is set in the environment, a new `ResilientMcpToolset` is registered pointing to `https://mcp.tavily.com/mcp`. The existing Exa and Parallel Search integrations remain untouched (additive strategy).

## Changes

- **`kady_agent/mcp.py`** — Added a conditional block that registers a Tavily Search MCP toolset when `TAVILY_API_KEY` is present, mirroring the existing Exa pattern.
- **`kady_agent/env.example`** — Added `TAVILY_API_KEY=` entry in the "Highly Recommended" section with a link to the Tavily dashboard.
- **`kady_agent/instructions/main_agent.md`** — Updated tool preference guidance and skill matching instructions to include Tavily Search MCP as an available option.

## Environment variable changes

- Added `TAVILY_API_KEY` (optional — Tavily MCP toolset only registered when set)

## Dependency changes

- None — Tavily is accessed via its HTTP MCP endpoint, no new Python packages required.

## Notes for reviewers

- The Tavily MCP block uses Bearer token auth in the Authorization header, matching Tavily's documented MCP server auth pattern.
- Existing Exa and Parallel Search blocks are completely untouched.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The additive Tavily migration is correct, consistent, and complete for the three files in scope. The `mcp.py` block mirrors the Exa and Parallel Search patterns exactly, using the right Tavily MCP endpoint (`https://mcp.tavily.com/mcp`) and `Authorization: Bearer` auth. `env.example` documents `TAVILY_API_KEY` with a reference URL, and `main_agent.md` updates both the proactive skill-matching example and the tool-preference sentence to include Tavily. One minor gap: `runtime.py`'s `_mcp_servers_snapshot()` adds conditional entries for `EXA_API_KEY` and `PARALLEL_API_KEY` for session telemetry, but has no corresponding entry for `TAVILY_API_KEY`. This doesn't affect runtime functionality but leaves Tavily absent from session metadata when it is enabled.
