### PR TITLE
feat: add Tavily Search as parallel option in Gemini CLI instructions

### DIFF
--- a/kady_agent/instructions/gemini_cli.md
+++ b/kady_agent/instructions/gemini_cli.md
@@ -63,7 +63,7 @@ Some skills correspond directly to MCP tools. **Always activate the skill before
 
 | Task | Activate skill first | Then use tool |
 |---|---|---|
-| Web search or URL retrieval | *parallel-search* (if available) | `web_search`, `web_fetch` |
+| Web search or URL retrieval | *parallel-search* or *tavily-search* (if available) | `web_search`, `web_fetch`, `tavily_search` |
 | Document conversion | *markitdown* or *docling* (if available) | Docling MCP tools |
 | Writing reports, papers, prose | **writing** | — |
 | Literature review | **literature-review** | — |
@@ -85,6 +85,7 @@ Any time Modal is mentioned — in the task description, in activated skill inst
 
 You have access to MCP servers. Use them instead of writing ad hoc code for the same tasks:
 - **Parallel Search** (`web_search`, `web_fetch`): Use for all web searches and URL content retrieval. Do not use `curl`, `requests`, or manual HTTP calls when Parallel can do it.
+- **Tavily Search** (`tavily_search`): Alternative web search provider. Use when Parallel Search is unavailable or when you need a second opinion on search results. Provides web search with built-in content extraction.
 - **Docling** (`convert_document_into_docling_document`, `export_docling_document_to_markdown`, `save_docling_document`): Use for converting documents (PDFs, DOCX, PPTX, etc.) to markdown. Convert the document, export to markdown, and save the `.md` file to the current working directory.
 
 **Tool priority rule:** If both an MCP tool and an activated skill cover the same task, the **skill's instructions take precedence** because the skill wraps the tool with tested parameters, error handling, and output formatting.


### PR DESCRIPTION
## Summary

Adds Tavily Search as a configurable alternative alongside the existing Parallel Search provider in the Gemini CLI expert instructions. This is an **additive** change — no existing functionality is removed.

## Changes

### `kady_agent/instructions/gemini_cli.md`
- **Skill-to-tool mapping table (line 66):** Added `tavily-search` as an alternative skill and `tavily_search` as an available tool for web search/URL retrieval tasks
- **MCP tools section (line 88):** Added a Tavily Search description block explaining when to use it (when Parallel Search is unavailable or as a second opinion)

## Dependency / Env Changes

- No dependency changes — this unit is purely instructional
- No env var changes — `TAVILY_API_KEY` is handled by the exa-search-additive unit

## Notes for Reviewers

- Parallel Search MCP block and `PARALLEL_API_KEY` remain unchanged
- The actual MCP server registration for Tavily is handled in the exa-search-additive unit; this unit only updates agent instructions


### Automated Review

- Passed after 1 attempt(s)
- Final review: Clean, minimal implementation. The two changes to `kady_agent/instructions/gemini_cli.md` exactly match the migration plan: (1) the skill-to-tool table row is extended to include `tavily-search` as an alternative skill and `tavily_search` as an additional tool, and (2) a Tavily Search MCP description block is added immediately after the Parallel Search block. Only the one planned file was modified, the Parallel Search entries are fully preserved, and the new text follows the existing documentation style. The prerequisite unit (exa-search-additive) covers MCP registration and the env var — this unit correctly limits itself to the instructional layer.
