### PR TITLE
fix(fusion): price the judge/fuser (2×) into fusion cost + forward reasoning to the fuser call

### DIFF
--- a/docs/openrouter-fusion.md
+++ b/docs/openrouter-fusion.md
@@ -29,7 +29,7 @@ A Fusion run threads from the picker to a real `openrouter/fusion` request and b
 
 Presets are defined in `web/src/lib/fusion-presets.ts` as `DEFAULT_FUSION_CONFIGS` — each a `{ id, name, note, config }` where `config` is the serialized Fusion request body. `loadFusionConfigs()` reads the user's saved presets from `localStorage` (key `fusionConfigs`), falling back to the built-ins; a `FUSION_DEFAULTS_VERSION` bump re-seeds new/updated built-ins while preserving user-added presets.
 
-`web/src/lib/use-models.ts` turns each preset into a synthetic picker entry with id `fusion/<presetId>`, provider `"Openrouter Fusion"`, the preset's DRACO `note`, and a **combined price = the sum of the panel models' catalogue prices** (so a two-Opus panel correctly shows double Opus pricing).
+`web/src/lib/use-models.ts` turns each preset into a synthetic picker entry with id `fusion/<presetId>`, provider `"Openrouter Fusion"`, the preset's DRACO `note`, and a **combined price = the sum of the panel models' catalogue prices plus twice the judge's** — a fusion turn bills N panel calls + 2 judge-model calls (the structured analysis and, under the `openrouter/fusion` alias, the outer call that writes the final answer). So a two-Opus panel judged by Opus shows 4× Opus pricing.
 
 ### 2. The run request (frontend → server)
 
@@ -39,7 +39,7 @@ When a `fusion/*` model is selected, `web/src/lib/use-agent.ts` includes the pre
 
 `server/src/api/sessions.ts` detects a `fusion/`-prefixed model and, for that turn:
 
-- resolves it via `resolveModel(model, registry, fusionConfig)` → `buildFusionModel()` (`server/src/agent/models.ts`), which builds an `openrouter/fusion` Pi `Model` **priced at the summed panel cost** (it refuses to run a $0-priced fusion model, so the spend cap always accrues);
+- resolves it via `resolveModel(model, registry, fusionConfig)` → `buildFusionModel()` (`server/src/agent/models.ts`), which builds an `openrouter/fusion` Pi `Model` **priced at the summed panel cost plus twice the judge's** (it refuses to run a $0-priced fusion model, so the spend cap always accrues);
 - stashes the `fusionConfig` for the session (`setFusionConfig`);
 - **empties Pi's local tool registry** with `session.setActiveToolsByName([])`, restored in a `finally` so non-fusion runs are unaffected.
 
@@ -60,17 +60,19 @@ That last step is load-bearing: Pi executes a model's returned tool calls by nam
     "analysis_models": ["...panel..."],
     "model": "<judge>",                              // synthesizer
     "max_tool_calls": 16,
-    "reasoning": { "effort": "xhigh" },              // reasoning + temperature live INSIDE the plugin
-    "temperature": 1
-  }]
+    "reasoning": { "effort": "xhigh" },              // forwarded to the panel + judge
+    "temperature": 1                                   // panel only — the judge always runs at temp 0
+  }],
+  "reasoning": { "effort": "xhigh" },                  // outer (fuser) call — writes the final answer
+  "temperature": 1
 }
 ```
 
-Reasoning and temperature are placed **inside the plugin** (a top-level `reasoning_effort` collides with Pi's own `reasoning.effort` and 400s). OpenRouter runs the panel server-side (each panel model with web search/fetch), the judge synthesizes, and the result streams back through Pi's normal SSE path.
+Reasoning and temperature are set **both inside the plugin** (forwarded to the panel; reasoning also reaches the judge — its temperature is pinned to 0 server-side) **and top-level** for the outer fuser call that writes the final answer. Pi's own reasoning fields are replaced with the preset's single canonical `reasoning` object (sending a raw `reasoning_effort` alongside `reasoning.effort` is what 400s). OpenRouter runs the panel server-side (each panel model with web search/fetch), the judge analyzes, the fuser synthesizes, and the result streams back through Pi's normal SSE path.
 
 ## Pricing & the spend cap
 
-Pi computes session cost from the resolved `Model.cost`, so the synthetic `openrouter/fusion` model carries the **summed panel pricing** and a Fusion run accrues against the project `spendLimitUsd` like any other. The catalogue lookup (`catalogueEntryFor` in `models.ts`) also strips OpenRouter reasoning-effort suffixes (`-xhigh`/`-high`/…) so suffixed ids price as their base model instead of $0 — without that, the cap would be blind to them. The displayed cost is an **estimate** from `web/src/data/models.json`; OpenRouter's actual multi-model bill may differ.
+Pi computes session cost from the resolved `Model.cost`, so the synthetic `openrouter/fusion` model carries the **summed panel pricing plus twice the judge's** (per OpenRouter's fusion-router docs, a fusion turn runs "N panel calls + 1 judge call in addition to your normal request", and under the router alias the outer request also runs the judge model) and a Fusion run accrues against the project `spendLimitUsd` like any other. The catalogue lookup (`catalogueEntryFor` in `models.ts`) also strips OpenRouter reasoning-effort suffixes (`-xhigh`/`-high`/…) so suffixed ids price as their base model instead of $0 — without that, the cap would be blind to them. The displayed cost is an **estimate** from `web/src/data/models.json`; OpenRouter's actual multi-model bill may differ.
 
 ## Managing presets (Settings → Fusion)
 
@@ -91,4 +93,4 @@ The **Fusion** tab in Settings lists your presets and an **Add Fusion config +**
 - `web/src/components/settings-dialog.tsx` — the Settings → Fusion management UI
 - `server/src/api/sessions.ts` — fusion detection, config stash, tool-registry disable
 - `server/src/agent/fusion-bridge.ts` — the `before_provider_request` body rewrite
-- `server/src/agent/models.ts` — `buildFusionModel` (summed-panel pricing) + `catalogueEntryFor`
+- `server/src/agent/models.ts` — `buildFusionModel` (panel + 2× judge pricing) + `catalogueEntryFor`

--- a/server/src/agent/fusion-bridge.ts
+++ b/server/src/agent/fusion-bridge.ts
@@ -56,14 +56,20 @@ function normalizeEffort(effort: string): string {
  *
  * Uses OpenRouter's Fusion *router* form (docs: routing/routers/fusion-router):
  * model "openrouter/fusion" + a single `plugins:[{id:"fusion", ...}]` carrying
- * the panel (analysis_models), judge (model), preset, max_tool_calls, and —
- * crucially — `reasoning`/`temperature` INSIDE the plugin (top-level reasoning
- * 400s against Pi's own reasoning.effort). Fusion is a server tool the model
- * chooses to call, and the plugin only injects it when the caller isn't sending
- * its own `tools`; Pi always does, so we drop the tools array and set
- * `tool_choice:"required"` to force deterministic fusion on every message of a
- * Fusion preset. (This drops Pi's local agentic tools for the fusion turn — the
- * panel runs web search server-side.)
+ * the panel (analysis_models), judge (model), preset, max_tool_calls, and
+ * `reasoning`/`temperature` INSIDE the plugin — the router forwards those to
+ * the panel calls (and reasoning to the judge; the judge's temperature is
+ * pinned to 0 server-side). The OUTER call — the fuser that writes the final
+ * answer — does NOT read plugin params, so the preset's reasoning/temperature
+ * are also set top-level, REPLACING Pi's own copies: exactly one canonical
+ * `reasoning` object is sent (the 400 this code used to guard against came
+ * from the preset's raw `reasoning_effort` coexisting with Pi's
+ * `reasoning.effort`, not from top-level reasoning per se). Fusion is a server
+ * tool the model chooses to call, and the plugin only injects it when the
+ * caller isn't sending its own `tools`; Pi always does, so we drop the tools
+ * array and set `tool_choice:"required"` to force deterministic fusion on
+ * every message of a Fusion preset. (This drops Pi's local agentic tools for
+ * the fusion turn — the panel runs web search server-side.)
  */
 export function buildFusionRequestBody(
   basePayload: Record<string, unknown>,
@@ -74,10 +80,14 @@ export function buildFusionRequestBody(
   const plugins = Array.isArray(fusionConfig.plugins) ? fusionConfig.plugins : [];
   const plugin = { ...((plugins[0] as Record<string, unknown> | undefined) ?? { id: "fusion" }) };
 
-  // Move the preset's reasoning/temperature INSIDE the fusion plugin (the router
-  // applies them to the panel + judge); normalise the effort to OpenRouter's set.
-  if (fusionConfig.reasoning_effort !== undefined) {
-    plugin.reasoning = { effort: normalizeEffort(String(fusionConfig.reasoning_effort)) };
+  // Copy the preset's reasoning/temperature INSIDE the fusion plugin (the router
+  // forwards them to the panel + judge); normalise the effort to OpenRouter's set.
+  const effort =
+    fusionConfig.reasoning_effort !== undefined
+      ? normalizeEffort(String(fusionConfig.reasoning_effort))
+      : undefined;
+  if (effort !== undefined) {
+    plugin.reasoning = { effort };
   }
   if (fusionConfig.temperature !== undefined) {
     plugin.temperature = fusionConfig.temperature;
@@ -100,11 +110,19 @@ export function buildFusionRequestBody(
   // only when the caller isn't managing tools, and with tool_choice:"required" +
   // that single tool, fusion runs deterministically.
   delete next.tools;
-  // Reasoning/temperature now live inside the plugin; remove any top-level copies
-  // so OpenRouter never sees conflicting reasoning fields.
+  // Top-level params drive the OUTER call (the fuser writing the final answer),
+  // which never reads the plugin's copies. Replace Pi's reasoning fields with
+  // the preset's single canonical `reasoning` object — sending both a raw
+  // `reasoning_effort` and `reasoning.effort` is what 400s.
   delete next.reasoning;
   delete next.reasoning_effort;
   delete next.temperature;
+  if (effort !== undefined) {
+    next.reasoning = { effort };
+  }
+  if (fusionConfig.temperature !== undefined) {
+    next.temperature = fusionConfig.temperature;
+  }
   return next;
 }
 

--- a/server/src/agent/models.ts
+++ b/server/src/agent/models.ts
@@ -134,15 +134,29 @@ function fusionPanelModels(fusionConfig: Record<string, unknown>): string[] {
   return Array.isArray(panel) ? (panel as string[]) : [];
 }
 
+/** Judge model id out of a Fusion request body (`plugins[0].model`), if set. */
+function fusionJudgeModel(fusionConfig: Record<string, unknown>): string | undefined {
+  const plugins = fusionConfig.plugins as Array<Record<string, unknown>> | undefined;
+  const judge = plugins?.[0]?.model;
+  return typeof judge === "string" ? judge : undefined;
+}
+
 /**
  * Build the Pi Model for an OpenRouter Fusion run. The id is "openrouter/fusion"
  * (the wire model the extension rewrites the body to), but its cost MUST be the
- * SUM of the analysis panel models' catalogue prices — otherwise Pi ledgers the
- * turn at $0 (cost flows from model.cost, not the rewritten HTTP body) and the
- * project spend cap is silently bypassed.
+ * SUM of the panel models' catalogue prices PLUS TWICE the judge's — otherwise
+ * Pi ledgers the turn at $0 (cost flows from model.cost, not the rewritten HTTP
+ * body) and the project spend cap is silently bypassed.
  *
- * Throws if the catalogue priced none of the panel models, so the caller can
- * abort the run rather than proceed with a $0-priced (cap-bypassing) Fusion model.
+ * Why twice the judge: per OpenRouter's fusion-router docs, a fusion turn runs
+ * "N panel calls + 1 judge call in addition to your normal request", and under
+ * the `openrouter/fusion` alias the outer request (the fuser that writes the
+ * final answer) resolves to the judge model — so the judge model is billed for
+ * two calls per turn (analysis + final synthesis). Panel-only pricing modeled
+ * ~3× a solo completion where the docs say to expect ~4-5×.
+ *
+ * Throws if the catalogue priced none of the panel/judge models, so the caller
+ * can abort the run rather than proceed with a $0-priced (cap-bypassing) model.
  */
 export function buildFusionModel(fusionConfig: Record<string, unknown>): Model<Api> {
   let costInput = 0;
@@ -155,10 +169,17 @@ export function buildFusionModel(fusionConfig: Record<string, unknown>): Model<A
     costOutput += entry.costOutput;
     priced++;
   }
+  const judgeId = fusionJudgeModel(fusionConfig);
+  const judgeEntry = judgeId ? catalogueEntryFor(stripOpenRouter(judgeId)) : undefined;
+  if (judgeEntry) {
+    costInput += 2 * judgeEntry.costInput;
+    costOutput += 2 * judgeEntry.costOutput;
+    priced++;
+  }
   if (priced === 0 || (costInput === 0 && costOutput === 0)) {
     throw new Error(
-      "Fusion panel has no priceable models in the catalogue; refusing to run a " +
-        "$0-priced Fusion model (spend cap would be bypassed).",
+      "Fusion panel/judge has no priceable models in the catalogue; refusing to " +
+        "run a $0-priced Fusion model (spend cap would be bypassed).",
     );
   }
   return {

--- a/server/test/fusion-bridge.test.ts
+++ b/server/test/fusion-bridge.test.ts
@@ -51,10 +51,11 @@ describe("buildFusionRequestBody", () => {
         temperature: 0.6,
       },
     ]);
-    // No conflicting top-level reasoning/temperature fields.
+    // Top-level params drive the OUTER (fuser) call: exactly one canonical
+    // reasoning object plus the preset temperature — never a raw reasoning_effort.
     expect("reasoning_effort" in out).toBe(false);
-    expect("reasoning" in out).toBe(false);
-    expect("temperature" in out).toBe(false);
+    expect(out.reasoning).toEqual({ effort: "xhigh" });
+    expect(out.temperature).toBe(0.6);
     // Base payload preserved + not mutated.
     expect(out.messages).toBe(basePayload.messages);
     expect(out.stream).toBe(true);
@@ -62,22 +63,34 @@ describe("buildFusionRequestBody", () => {
     expect("plugins" in basePayload).toBe(false);
   });
 
-  it("normalises effort inside the plugin and strips top-level reasoning + alias", () => {
+  it("normalises effort in plugin and top-level, replacing Pi's own reasoning fields", () => {
     const withReasoning = { ...basePayload, reasoning: { effort: "low" }, reasoning_effort: "low" };
     const out = buildFusionRequestBody(withReasoning, { ...fusionConfig, reasoning_effort: "medium" });
     const plugin = (out.plugins as Array<Record<string, unknown>>)[0];
     expect(plugin.reasoning).toEqual({ effort: "medium" });
-    expect("reasoning" in out).toBe(false);
+    expect(out.reasoning).toEqual({ effort: "medium" });
     expect("reasoning_effort" in out).toBe(false);
   });
 
-  it("omits temperature from the plugin when the preset has none", () => {
+  it("omits temperature everywhere when the preset has none", () => {
     const noTemp = { ...fusionConfig };
     delete (noTemp as { temperature?: number }).temperature;
-    const out = buildFusionRequestBody(basePayload, noTemp);
+    const out = buildFusionRequestBody({ ...basePayload, temperature: 0.2 }, noTemp);
     expect(out.model).toBe("openrouter/fusion");
     const plugin = (out.plugins as Array<Record<string, unknown>>)[0];
     expect("temperature" in plugin).toBe(false);
+    // Pi's own temperature is stripped too — the fusion turn runs the preset's
+    // sampling config (or provider defaults), not the previous model's.
+    expect("temperature" in out).toBe(false);
+  });
+
+  it("strips Pi's reasoning without adding one when the preset has no effort", () => {
+    const noEffort = { ...fusionConfig };
+    delete (noEffort as { reasoning_effort?: string }).reasoning_effort;
+    const out = buildFusionRequestBody({ ...basePayload, reasoning: { effort: "low" } }, noEffort);
+    expect("reasoning" in out).toBe(false);
+    const plugin = (out.plugins as Array<Record<string, unknown>>)[0];
+    expect("reasoning" in plugin).toBe(false);
   });
 
   it("returns the base payload unchanged when there is no fusionConfig", () => {

--- a/server/test/models.test.ts
+++ b/server/test/models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { catalogueEntryFor } from "../src/agent/models.ts";
+import { buildFusionModel, catalogueEntryFor } from "../src/agent/models.ts";
 
 // Reasoning-effort suffixes ("...-xhigh", "...-high", …) are an OpenRouter
 // routing form, not separate catalogue rows. Before the fix they missed the
@@ -27,5 +27,52 @@ describe("catalogueEntryFor (reasoning-effort suffix pricing)", () => {
 
   it("returns undefined for an unknown model", () => {
     expect(catalogueEntryFor("nonexistent/model-xyz")).toBeUndefined();
+  });
+});
+
+// A fusion turn bills N panel calls + 2 judge-model calls (structured analysis
+// + the outer request that writes the final answer — both the judge model under
+// the openrouter/fusion alias). Panel-only pricing under-ledgered every turn by
+// two judge calls, eroding the spend cap.
+describe("buildFusionModel (panel + judge pricing)", () => {
+  const fusionConfig = (panel: string[], judge?: string) => ({
+    model: "openrouter/fusion",
+    plugins: [
+      {
+        id: "fusion",
+        analysis_models: panel,
+        ...(judge ? { model: judge } : {}),
+      },
+    ],
+  });
+
+  it("prices as the panel sum plus twice the judge", () => {
+    const opus = catalogueEntryFor("anthropic/claude-opus-4.8")!;
+    const gpt = catalogueEntryFor("openai/gpt-5.5")!;
+    const model = buildFusionModel(
+      fusionConfig(["anthropic/claude-opus-4.8", "openai/gpt-5.5"], "anthropic/claude-opus-4.8"),
+    );
+    expect(model.cost.input).toBeCloseTo(opus.costInput + gpt.costInput + 2 * opus.costInput);
+    expect(model.cost.output).toBeCloseTo(opus.costOutput + gpt.costOutput + 2 * opus.costOutput);
+  });
+
+  it("still prices the panel when the judge is missing from the catalogue", () => {
+    const opus = catalogueEntryFor("anthropic/claude-opus-4.8")!;
+    const model = buildFusionModel(
+      fusionConfig(["anthropic/claude-opus-4.8"], "nonexistent/judge-xyz"),
+    );
+    expect(model.cost.input).toBeCloseTo(opus.costInput);
+  });
+
+  it("prices a judge-only config (catalogue-priced judge, unpriceable panel)", () => {
+    const opus = catalogueEntryFor("anthropic/claude-opus-4.8")!;
+    const model = buildFusionModel(
+      fusionConfig(["nonexistent/panelist-xyz"], "anthropic/claude-opus-4.8"),
+    );
+    expect(model.cost.input).toBeCloseTo(2 * opus.costInput);
+  });
+
+  it("throws when neither panel nor judge is priceable (never run at $0)", () => {
+    expect(() => buildFusionModel(fusionConfig(["nonexistent/model-xyz"]))).toThrow(/\$0/);
   });
 });

--- a/web/src/lib/fusion-presets.ts
+++ b/web/src/lib/fusion-presets.ts
@@ -157,6 +157,18 @@ export function fusionPanelModels(cfg: Record<string, unknown>): string[] {
   return Array.isArray(legacy) ? (legacy as string[]) : [];
 }
 
+/**
+ * Judge model id for a parsed Fusion body (`plugins[0].model`), if set. The
+ * judge is billed for TWO calls per fusion turn — the structured analysis and,
+ * under the `openrouter/fusion` alias, the outer request that writes the final
+ * answer — so pricing must count it twice on top of the panel sum.
+ */
+export function fusionJudgeModel(cfg: Record<string, unknown>): string | undefined {
+  const plugins = cfg.plugins as Array<Record<string, unknown>> | undefined;
+  const judge = plugins?.[0]?.model;
+  return typeof judge === "string" ? judge : undefined;
+}
+
 // Ids of built-in presets that shipped in earlier versions and are retired now.
 // They're dropped on migration so they don't linger as fake "user" configs.
 const RETIRED_DEFAULT_IDS = new Set(["research-fusion", "frontier-council", "budget-trio"]);

--- a/web/src/lib/use-models.ts
+++ b/web/src/lib/use-models.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import staticModels from "@/data/models.json";
 import type { Model } from "@/components/model-selector";
 import { apiFetch, onProjectChange } from "@/lib/projects";
-import { fusionPanelModels, loadFusionConfigs } from "@/lib/fusion-presets";
+import { fusionJudgeModel, fusionPanelModels, loadFusionConfigs } from "@/lib/fusion-presets";
 
 const OPENROUTER_MODELS = staticModels as Model[];
 
@@ -86,22 +86,37 @@ export function useModels(): UseModelsReturn {
       }
 
       const panel = fusionPanelModels(cfg);
+      const judge = fusionJudgeModel(cfg);
       const reasoning = (cfg.reasoning_effort as string) || "standard";
 
-      // Combined input/output price = sum of the panel models' catalogue prices.
+      // Combined input/output price = sum of the panel models' catalogue prices
+      // plus TWICE the judge's (analysis call + the outer call that writes the
+      // final answer — both run the judge model under the openrouter/fusion alias).
       let totalPrompt = 0;
       let totalCompletion = 0;
       const missing: string[] = [];
-      for (const modelId of panel) {
+      const priceOf = (modelId: string) => {
         const cleanId = modelId.replace(/^openrouter\//, "");
-        const found = OPENROUTER_MODELS.find(
+        return OPENROUTER_MODELS.find(
           (m) => m.id === `openrouter/${cleanId}` || m.id === modelId,
         );
+      };
+      for (const modelId of panel) {
+        const found = priceOf(modelId);
         if (found) {
           totalPrompt += found.pricing.prompt;
           totalCompletion += found.pricing.completion;
         } else {
-          missing.push(cleanId);
+          missing.push(modelId.replace(/^openrouter\//, ""));
+        }
+      }
+      if (judge) {
+        const found = priceOf(judge);
+        if (found) {
+          totalPrompt += 2 * found.pricing.prompt;
+          totalCompletion += 2 * found.pricing.completion;
+        } else {
+          missing.push(`${judge.replace(/^openrouter\//, "")} (judge)`);
         }
       }
 
@@ -121,7 +136,7 @@ export function useModels(): UseModelsReturn {
         modality: "text->text",
         description:
           `OpenRouter Fusion • ${panelNames} • ${reasoning} reasoning` +
-          `\n$${totalPrompt.toFixed(2)} in / $${totalCompletion.toFixed(2)} out per 1M tok (combined)` +
+          `\n$${totalPrompt.toFixed(2)} in / $${totalCompletion.toFixed(2)} out per 1M tok (panel + 2× judge)` +
           noteLine +
           missingLine,
         isFusion: true,


### PR DESCRIPTION
## What

Follow-up to #20. Fixes a fusion pricing bug and a sampling-config gap, both server-side and in the picker:

1. **The judge/fuser was never priced.** `buildFusionModel()` and the picker's combined price summed only the `analysis_models` panel — the judge model was ledgered at $0 on every fusion turn.
2. **The fuser call ran without the preset's reasoning config.** The bridge stripped all top-level `reasoning`/`temperature` from the outgoing body, so the outer call that writes the final answer ran at provider-default effort while only the panel + judge got `xhigh`.

## Why 2× the judge

Per OpenRouter's [fusion-router docs](https://openrouter.ai/docs/guides/routing/routers/fusion-router), a fusion turn runs **"N panel calls + 1 judge call in addition to your normal request"** — and under the `openrouter/fusion` alias (the form this integration always sends), the plugin's judge model [also becomes the model that writes the final answer](https://openrouter.ai/docs/guides/features/plugins/fusion). So the judge model is billed for two calls per turn: the structured analysis and the final synthesis. Panel-only pricing modeled ~3× a solo completion where the docs say to expect ~4–5×, quietly eroding the project spend cap on every fusion message.

## Before / after (model picker)

Every preset gains the previously-missing 2× Opus 4.8 judge (+$10.00 in / +$50.00 out per 1M tok). The budget trio is the starkest: the panel is cheap, but the frontier judge dominates its real cost.

| Before (panel only) | After (panel + 2× judge) |
|---|---|
| ![before](https://raw.githubusercontent.com/ahuserious/k-dense-byok/assets/fusion-fuser-pricing/fusion-picker-before.png) | ![after](https://raw.githubusercontent.com/ahuserious/k-dense-byok/assets/fusion-fuser-pricing/fusion-picker-after.png) |

## Changes

- `server/src/agent/models.ts` — `buildFusionModel()` adds `2 ×` the judge's catalogue price to the panel sum; a config whose judge is priceable no longer throws just because the panel isn't.
- `web/src/lib/fusion-presets.ts` — new `fusionJudgeModel()` helper (mirrors `fusionPanelModels()`).
- `web/src/lib/use-models.ts` — picker combined price includes the judge ×2; an unpriceable judge now shows in the ⚠ missing-price line; price line labeled `(panel + 2× judge)`.
- `server/src/agent/fusion-bridge.ts` — the preset's canonical top-level `reasoning: { effort }` + `temperature` now REPLACE Pi's copies instead of being deleted, so the fuser call runs at the preset's effort. (The historical 400 came from a raw `reasoning_effort` coexisting with Pi's `reasoning.effort`, not from top-level reasoning itself.) Also documents OpenRouter's actual plugin semantics: plugin `temperature` reaches the panel only — the judge is pinned to temperature 0 server-side.
- `docs/openrouter-fusion.md` — pricing + parameter semantics corrected.

## Testing

- `server`: 53/53 vitest pass, including 4 new `buildFusionModel` pricing cases (panel+judge sum, judge-missing, judge-only, all-unpriceable throws).
- `web`: `tsc --noEmit` clean. (The 18 pre-existing project-storage/pdf-annotations test failures reproduce identically on clean `main`.)
- Live against OpenRouter: the exact bridge-produced body passes OpenRouter's request validation (probed: an oversized 9-model panel is rejected `400` *before* the credit gate, while this body reaches the credit gate), and the top-level `reasoning`+`temperature` form was verified end-to-end on a free model (200, `reasoning_tokens` > 0). A full paid fusion turn wasn't run (account out of credits); recommend one smoke turn before/after merge.

## Notes

- Pricing remains a *rate estimate* (rates × the outer call's reported usage), as before — exact accounting would read `usage.cost` from OpenRouter's usage accounting; left as a follow-up.
- If a non-alias (server-tool) fusion form is ever added, the fuser may differ from the judge and the ×2 collapse would need splitting into judge×1 + outer×1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

