### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ OPENROUTER_API_KEY=
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
 
+## Optional: Atlas Cloud hosted models
+
+# Atlas Cloud exposes an OpenAI-compatible endpoint for hosted models. Set the
+# key below, then either choose an `atlascloud/*` model in the UI or route a
+# bare DEFAULT_MODEL_ID by setting DEFAULT_MODEL_PROVIDER="atlascloud".
+# ATLASCLOUD_API_KEY=
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+
+
 ## Model defaults (optional)
 
 # Default model for the agent. This is a bare provider model id; the provider

--- a/server/src/agent/models.ts
+++ b/server/src/agent/models.ts
@@ -1,13 +1,14 @@
 /**
  * Model resolution for the Pi agent.
  *
- * Two providers are supported, matching the product requirement:
+ * Three providers are supported, matching the product requirement:
  *   - OpenRouter (built-in Pi provider, key via OPENROUTER_API_KEY)
+ *   - Atlas Cloud (OpenAI-compatible, key via ATLASCLOUD_API_KEY)
  *   - Ollama (local, OpenAI-compatible at OLLAMA_BASE_URL)
  *
  * The frontend picker sends model refs like "openrouter/anthropic/claude-opus-4.8"
- * or "ollama/llama3". OpenRouter has thousands of models that aren't all in Pi's
- * built-in table, so when `find()` misses we synthesize a Model from the
+ * or "atlascloud/qwen/qwen3.5-flash". OpenRouter has thousands of models that
+ * aren't all in Pi's built-in table, so when `find()` misses we synthesize a Model from the
  * frontend catalogue (web/src/data/models.json) — Pi computes usage.cost from
  * `model.cost`, so we populate it from the catalogue's per-1M pricing.
  */
@@ -28,6 +29,8 @@ import {
 // "vendor/model" ids and Bearer auth as OpenRouter.
 const OPENROUTER_BASE_URL =
   process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1";
+const ATLASCLOUD_BASE_URL =
+  process.env.ATLASCLOUD_BASE_URL ?? "https://api.atlascloud.ai/v1";
 const CATALOGUE_PATH = path.join(REPO_ROOT, "web", "src", "data", "models.json");
 
 interface CatalogueEntry {
@@ -88,6 +91,31 @@ function loadCatalogue(): Map<string, CatalogueEntry> {
 // project spend cap. These are stripped to price as the base model.
 const EFFORT_SUFFIXES = ["-xhigh", "-high", "-medium", "-low", "-minimal", "-none"];
 
+const ATLAS_CLOUD_MODELS = new Map<string, CatalogueEntry>([
+  [
+    "qwen/qwen3.5-flash",
+    {
+      label: "Qwen3.5 Flash",
+      contextWindow: 1_000_000,
+      maxTokens: 8192,
+      costInput: 0.1,
+      costOutput: 0.4,
+      input: ["text"],
+    },
+  ],
+  [
+    "deepseek-ai/deepseek-v4-pro",
+    {
+      label: "DeepSeek V4 Pro",
+      contextWindow: 1_048_576,
+      maxTokens: 8192,
+      costInput: 1.68,
+      costOutput: 3.38,
+      input: ["text"],
+    },
+  ],
+]);
+
 /**
  * Catalogue lookup tolerant of a reasoning-effort suffix: exact match first
  * (so "-fast", a distinct catalogue model with its own pricing, is never
@@ -114,6 +142,27 @@ function buildOpenRouterModel(orId: string): Model<Api> {
     api: "openai-completions",
     provider: "openrouter",
     baseUrl: OPENROUTER_BASE_URL,
+    reasoning: true,
+    input: cat?.input ?? ["text"],
+    cost: {
+      input: cat?.costInput ?? 0,
+      output: cat?.costOutput ?? 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: cat?.contextWindow ?? 128_000,
+    maxTokens: cat?.maxTokens ?? 8192,
+  };
+}
+
+function buildAtlasCloudModel(modelId: string): Model<Api> {
+  const cat = ATLAS_CLOUD_MODELS.get(modelId);
+  return {
+    id: modelId,
+    name: cat?.label ?? modelId,
+    api: "openai-completions",
+    provider: "atlascloud",
+    baseUrl: ATLASCLOUD_BASE_URL,
     reasoning: true,
     input: cat?.input ?? ["text"],
     cost: {
@@ -194,6 +243,8 @@ function buildOllamaModel(name: string): Model<Api> {
 export function setupAuth(authStorage: AuthStorage): void {
   const orKey = process.env.OPENROUTER_API_KEY || process.env.OR_API_KEY;
   if (orKey) authStorage.setRuntimeApiKey("openrouter", orKey);
+  const atlasKey = process.env.ATLASCLOUD_API_KEY;
+  if (atlasKey) authStorage.setRuntimeApiKey("atlascloud", atlasKey);
   // Local Ollama ignores the key, but Pi requires *some* auth to resolve.
   authStorage.setRuntimeApiKey("ollama", "ollama");
 }
@@ -224,10 +275,16 @@ export function resolveModel(
   if (r.startsWith("ollama/")) {
     return buildOllamaModel(r.slice("ollama/".length));
   }
+  if (r.startsWith("atlascloud/")) {
+    return buildAtlasCloudModel(r.slice("atlascloud/".length));
+  }
   // .env.example documents a bare DEFAULT_MODEL_ID (e.g. "llama3") routed by
   // DEFAULT_MODEL_PROVIDER; honor that instead of misrouting to OpenRouter.
   if (usingDefault && DEFAULT_MODEL_PROVIDER.toLowerCase() === "ollama") {
     return buildOllamaModel(r);
+  }
+  if (usingDefault && DEFAULT_MODEL_PROVIDER.toLowerCase() === "atlascloud") {
+    return buildAtlasCloudModel(r);
   }
   const orId = stripOpenRouter(r);
   return registry.find("openrouter", orId) ?? buildOpenRouterModel(orId);

--- a/server/test/models.test.ts
+++ b/server/test/models.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { catalogueEntryFor } from "../src/agent/models.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { catalogueEntryFor, resolveModel, setupAuth } from "../src/agent/models.ts";
+
+const registry = { find: vi.fn(() => undefined) };
+
+afterEach(() => {
+  delete process.env.ATLASCLOUD_API_KEY;
+  vi.clearAllMocks();
+});
 
 // Reasoning-effort suffixes ("...-xhigh", "...-high", …) are an OpenRouter
 // routing form, not separate catalogue rows. Before the fix they missed the
@@ -27,5 +34,43 @@ describe("catalogueEntryFor (reasoning-effort suffix pricing)", () => {
 
   it("returns undefined for an unknown model", () => {
     expect(catalogueEntryFor("nonexistent/model-xyz")).toBeUndefined();
+  });
+});
+
+describe("Atlas Cloud model resolution", () => {
+  it("builds Atlas Cloud OpenAI-compatible models from atlascloud refs", () => {
+    const model = resolveModel(
+      "atlascloud/qwen/qwen3.5-flash",
+      registry as never,
+    );
+
+    expect(model).toMatchObject({
+      id: "qwen/qwen3.5-flash",
+      name: "Qwen3.5 Flash",
+      provider: "atlascloud",
+      api: "openai-completions",
+      baseUrl: "https://api.atlascloud.ai/v1",
+      contextWindow: 1_000_000,
+      maxTokens: 8192,
+    });
+    expect(model.cost.input).toBe(0.1);
+    expect(model.cost.output).toBe(0.4);
+    expect(registry.find).not.toHaveBeenCalledWith(
+      "openrouter",
+      "atlascloud/qwen/qwen3.5-flash",
+    );
+  });
+
+  it("wires ATLASCLOUD_API_KEY into Pi auth storage", () => {
+    process.env.ATLASCLOUD_API_KEY = "atlas-test-key";
+    const authStorage = { setRuntimeApiKey: vi.fn() };
+
+    setupAuth(authStorage as never);
+
+    expect(authStorage.setRuntimeApiKey).toHaveBeenCalledWith(
+      "atlascloud",
+      "atlas-test-key",
+    );
+    expect(authStorage.setRuntimeApiKey).toHaveBeenCalledWith("ollama", "ollama");
   });
 });

--- a/web/src/components/model-selector.tsx
+++ b/web/src/components/model-selector.tsx
@@ -47,6 +47,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   Anthropic: "text-orange-600 dark:text-orange-400",
   OpenAI:    "text-emerald-600 dark:text-emerald-400",
   DeepSeek:  "text-cyan-600 dark:text-cyan-400",
+  "Atlas Cloud": "text-sky-600 dark:text-sky-400",
   xAI:       "text-rose-600 dark:text-rose-400",
   Meta:      "text-indigo-600 dark:text-indigo-400",
   Ollama:    "text-teal-600 dark:text-teal-400",

--- a/web/src/lib/use-models.ts
+++ b/web/src/lib/use-models.ts
@@ -8,6 +8,30 @@ import { apiFetch, onProjectChange } from "@/lib/projects";
 import { fusionPanelModels, loadFusionConfigs } from "@/lib/fusion-presets";
 
 const OPENROUTER_MODELS = staticModels as Model[];
+const ATLASCLOUD_MODELS: Model[] = [
+  {
+    id: "atlascloud/qwen/qwen3.5-flash",
+    label: "Qwen3.5 Flash",
+    provider: "Atlas Cloud",
+    tier: "mid",
+    context_length: 1_000_000,
+    pricing: { prompt: 0.1, completion: 0.4 },
+    modality: "text->text",
+    description:
+      "Atlas Cloud OpenAI-compatible hosted model via ATLASCLOUD_API_KEY.",
+  },
+  {
+    id: "atlascloud/deepseek-ai/deepseek-v4-pro",
+    label: "DeepSeek V4 Pro",
+    provider: "Atlas Cloud",
+    tier: "high",
+    context_length: 1_048_576,
+    pricing: { prompt: 1.68, completion: 3.38 },
+    modality: "text->text",
+    description:
+      "Atlas Cloud OpenAI-compatible reasoning model via ATLASCLOUD_API_KEY.",
+  },
+];
 
 interface OllamaListResponse {
   available?: boolean;
@@ -15,7 +39,7 @@ interface OllamaListResponse {
 }
 
 export interface UseModelsReturn {
-  /** Every model available to the user: static OpenRouter catalogue + live Ollama tags + user Fusion configs. */
+  /** Every model available to the user: hosted catalogues + live Ollama tags + user Fusion configs. */
   models: Model[];
   /** Just the Ollama-sourced entries, in the order returned by the backend. */
   ollamaModels: Model[];
@@ -26,8 +50,8 @@ export interface UseModelsReturn {
 }
 
 /**
- * Merge the static OpenRouter-derived `models.json` with whatever models
- * are currently pulled in the user's local Ollama server.
+ * Merge the hosted model catalogues with whatever models are currently pulled
+ * in the user's local Ollama server.
  *
  * Ollama discovery is best-effort: if the daemon is offline we silently
  * fall back to OpenRouter-only. The hook re-fetches on project change to
@@ -134,7 +158,12 @@ export function useModels(): UseModelsReturn {
   return {
     // Drop the static `openrouter/fusion` catalogue row — the presets above
     // replace it (it was a non-functional $0 duplicate).
-    models: [...fusionModels, ...OPENROUTER_MODELS.filter((m) => !m.isFusion), ...ollamaModels],
+    models: [
+      ...fusionModels,
+      ...OPENROUTER_MODELS.filter((m) => !m.isFusion),
+      ...ATLASCLOUD_MODELS,
+      ...ollamaModels,
+    ],
     ollamaModels,
     ollamaAvailable,
     refresh: fetchOllama,


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an OpenAI-compatible hosted model provider
- wire `ATLASCLOUD_API_KEY` / optional `ATLASCLOUD_BASE_URL` into backend model auth and resolution
- add Atlas Cloud entries to the model picker with live-verified model IDs and pricing
- document the optional environment variables in `.env.example`

## Validation
- `npm test -- models.test.ts` in `server` (5 passed)
- `npm run typecheck` in `server`
- `npm run lint -- src/lib/use-models.ts src/components/model-selector.tsx` in `web` (passes with an existing `FUSION_BADGE` unused warning)
- `npm run build` in `web`
- `git diff --check`
- verified `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` are present in the live Atlas Cloud `/v1/models` response

No README, sponsor, logo, credits, or partner-promotion changes were added.
