### PR TITLE
docs: add a remote search MCP setup example

### DIFF
--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -16,6 +16,16 @@ A server hosted somewhere on the internet. You need its URL and, usually, an acc
 - **Server URL**: e.g. `https://mcp.example.com/mcp`
 - **Bearer token**: the access token, if the service requires one
 
+#### Example: Parallel Search
+
+To add optional web search and URL fetching through Parallel Search MCP, use:
+
+- **Name**: `parallel-search`
+- **Server URL**: `https://search.parallel.ai/mcp`
+- **Bearer token**: leave blank
+
+The default endpoint requires no account or API key. After you test and save it, its `web_search` and `web_fetch` tools are available in new chat tabs.
+
 ### Local (command)
 
 A small program that runs on your own computer when needed. These are typically published as npm packages and need no hosting.


### PR DESCRIPTION
## Summary

- add a copyable Parallel Search example to the remote MCP setup guide
- document the no-account, no-key setup and the tools available in new chat tabs

## Validation

- `git diff --check`
- reviewed the field values against the current URL-only MCP configuration schema

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.
