### PR TITLE
Add Docker support and auto-detect context windows for local models

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Node / build artifacts
+**/node_modules
+**/.next
+**/dist
+**/out
+**/coverage
+
+# Local data & env — must never enter the image
+/.env
+/projects
+**/.venv
+**/uv.lock
+
+# Git / CI / tooling
+.git
+.github
+.dockerignore
+
+# Logs
+**/*.log
+
+# OS cruft
+.DS_Store
+**/*.swp

--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,11 @@ OLLAMA_BASE_URL=http://localhost:11434
 # For local servers only: models are treated as free, so pointing this at a
 # paid hosted gateway would leave that spend untracked and uncapped.
 #OPENAI_COMPATIBLE_BASE_URL=http://localhost:1234
+# Use the ROOT, not a /v1 path: Kady appends /v1/models itself.
+# Declared context window for the server above; must match its real context
+# (llama.cpp --ctx-size). A window smaller than the prompt makes every run send
+# ~0 output tokens. e.g. 131072 for a 128K-served llama.cpp.
+#OPENAI_COMPATIBLE_CONTEXT_WINDOW=32768
 
 
 ## Optional: Modal remote compute

--- a/.env.example
+++ b/.env.example
@@ -127,9 +127,11 @@ OLLAMA_BASE_URL=http://localhost:11434
 # paid hosted gateway would leave that spend untracked and uncapped.
 #OPENAI_COMPATIBLE_BASE_URL=http://localhost:1234
 # Use the ROOT, not a /v1 path: Kady appends /v1/models itself.
-# Declared context window for the server above; must match its real context
-# (llama.cpp --ctx-size). A window smaller than the prompt makes every run send
-# ~0 output tokens. e.g. 131072 for a 128K-served llama.cpp.
+# Usually unnecessary: Kady reads each model's real context window off
+# /v1/models (llama.cpp meta.n_ctx, vLLM max_model_len) and prefers it. Set this
+# only as a fallback for servers that report nothing there — LM Studio, or a
+# llama.cpp router listing a model it hasn't loaded yet. A window smaller than
+# the prompt makes every run send ~0 output tokens.
 #OPENAI_COMPATIBLE_CONTEXT_WINDOW=32768
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,21 @@
 # syntax=docker/dockerfile:1
 #
-# Kady (K-Dense BYOK) — single-container image.
+# Kady (K-Dense BYOK) — single-container image: the TS backend (Pi agent,
+# :8000) and Next.js frontend (:3000) as start.mjs starts them, inside one
+# isolated container so the agent sandbox (bash/python/latex) never runs as
+# the host user and never sees the docker socket.
 #
-# Builds BOTH runtime services exactly as start.mjs starts them on a host —
-# the TS backend (Pi agent, port 8000) and the Next.js frontend (port 3000) —
-# inside one isolated container. The container is deliberately an OS-level
-# boundary for the agent's bash/python/latex sandbox: agent tools never run
-# as the host user and never see the docker socket.
-#
-# Build with LaTeX:        docker build -t kady:latest .
-# Build WITHOUT LaTeX:     docker build --build-arg WITH_LATEX=0 -t kady:lite .
+#   docker build -t kady:latest .                                     # with LaTeX
+#   docker build --build-arg WITH_LATEX=0 -t kady:lite .              # without
 
-# ---- Build args -------------------------------------------------------------
 ARG NODE_VERSION=22
-# Include TeX Live (latexmk/pdflatex/synctex) for LaTeX compile + SyncTeX.
-# Set to 0 for a smaller "lite" image; the app already degrades gracefully
-# (compile returns a clean "compiler not found"; SyncTeX reports unavailable).
+# TeX Live for LaTeX compile + SyncTeX; set 0 for a smaller image (the app
+# degrades gracefully when TeX is missing).
 ARG WITH_LATEX=1
 
 FROM node:${NODE_VERSION}-bookworm-slim AS base
 
-# Redeclare so the stage RUN can use it (global ARGs only reach the FROM line).
+# Redeclare: global ARGs only reach the FROM line.
 ARG WITH_LATEX=1
 
 # ---- OS packages ------------------------------------------------------------
@@ -47,8 +42,7 @@ RUN set -eux; \
     fi; \
     rm -rf /var/lib/apt/lists/*
 
-# uv — the agent runs ALL sandbox Python through uv, and the backend shells
-# into it for the scientific helper venv. Must be on PATH for every user.
+# uv — all sandbox Python (and the helper venv) runs through it.
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
@@ -64,21 +58,15 @@ RUN cd server && npm ci --no-audit --no-fund
 # ---- Source ------------------------------------------------------------------
 COPY . .
 
-# Bake the scientific file-preview helper venv (numpy/scipy/anndata/rdkit/
-# gemmi/…) at build time so first boot doesn't need to download them.
+# Bake the scientific helper venv (numpy/anndata/rdkit/…) at build time.
 RUN cd server/src/helpers && uv sync
 
-# A present-but-empty root .env stops start.mjs from copying .env.example over
-# the real API keys/env passed in from docker compose. All config stays
-# external to the image.
+# Empty root .env stops start.mjs from copying .env.example over compose keys.
 RUN touch /app/.env
 
 # ---- Runtime -----------------------------------------------------------------
-# 0.0.0.0: the backend must listen on the container's network interface so the
-# host-published port can reach it (binding 127.0.0.1 would be container-local
-# only). Host ports are bound to 127.0.0.1 in compose, so this is still
-# localhost-only from the host's perspective. HOSTNAME=0.0.0.0 tells `next dev`
-# to do the same for the frontend.
+# Listen on all interfaces inside the container; compose still publishes
+# 127.0.0.1 only. HOSTNAME=0.0.0.0 does the same for `next dev`.
 ENV \
     HOME=/home/node \
     KADY_PROJECTS_ROOT=/data/projects \
@@ -87,8 +75,7 @@ ENV \
     KADY_HOST=0.0.0.0 \
     HOSTNAME=0.0.0.0
 
-# Data dirs + writable app dir. Owned by `node` (uid 1000); the entrypoint
-# re-fixes bind-mount ownership at runtime and drops privileges to node.
+# Owned by node; the entrypoint re-fixes bind-mounts and drops to node.
 RUN mkdir -p /data/projects /data/config/skills-cache \
     && chown -R node:node /data /app
 
@@ -98,6 +85,5 @@ COPY docker-entrypoint.sh /usr/local/bin/kady-entrypoint
 RUN chmod +x /usr/local/bin/kady-entrypoint
 
 ENTRYPOINT ["/usr/local/bin/kady-entrypoint"]
-# Matches `./start.sh` but without trying to open a host browser. Installs the
-# pinned harness, preps projects/skills, frees ports, starts both services.
+# Matches ./start.sh without opening a host browser.
 CMD ["node", "start.mjs", "--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1
+#
+# Kady (K-Dense BYOK) — single-container image.
+#
+# Builds BOTH runtime services exactly as start.mjs starts them on a host —
+# the TS backend (Pi agent, port 8000) and the Next.js frontend (port 3000) —
+# inside one isolated container. The container is deliberately an OS-level
+# boundary for the agent's bash/python/latex sandbox: agent tools never run
+# as the host user and never see the docker socket.
+#
+# Build with LaTeX:        docker build -t kady:latest .
+# Build WITHOUT LaTeX:     docker build --build-arg WITH_LATEX=0 -t kady:lite .
+
+# ---- Build args -------------------------------------------------------------
+ARG NODE_VERSION=22
+# Include TeX Live (latexmk/pdflatex/synctex) for LaTeX compile + SyncTeX.
+# Set to 0 for a smaller "lite" image; the app already degrades gracefully
+# (compile returns a clean "compiler not found"; SyncTeX reports unavailable).
+ARG WITH_LATEX=1
+
+FROM node:${NODE_VERSION}-bookworm-slim AS base
+
+# Redeclare so the stage RUN can use it (global ARGs only reach the FROM line).
+ARG WITH_LATEX=1
+
+# ---- OS packages ------------------------------------------------------------
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        lsof \
+        util-linux \
+        python3 \
+        python3-pip \
+        python3-venv; \
+    if [ "${WITH_LATEX}" = "1" ]; then \
+        apt-get install -y --no-install-recommends \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            lmodern \
+            cm-super; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
+
+# uv — the agent runs ALL sandbox Python through uv, and the backend shells
+# into it for the scientific helper venv. Must be on PATH for every user.
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv --version
+
+# ---- Dependencies (layer-cached ahead of source) -----------------------------
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json ./web/
+RUN cd web && npm ci --no-audit --no-fund
+
+COPY server/package.json server/package-lock.json ./server/
+RUN cd server && npm ci --no-audit --no-fund
+
+# ---- Source ------------------------------------------------------------------
+COPY . .
+
+# Bake the scientific file-preview helper venv (numpy/scipy/anndata/rdkit/
+# gemmi/…) at build time so first boot doesn't need to download them.
+RUN cd server/src/helpers && uv sync
+
+# A present-but-empty root .env stops start.mjs from copying .env.example over
+# the real API keys/env passed in from docker compose. All config stays
+# external to the image.
+RUN touch /app/.env
+
+# ---- Runtime -----------------------------------------------------------------
+# 0.0.0.0: the backend must listen on the container's network interface so the
+# host-published port can reach it (binding 127.0.0.1 would be container-local
+# only). Host ports are bound to 127.0.0.1 in compose, so this is still
+# localhost-only from the host's perspective. HOSTNAME=0.0.0.0 tells `next dev`
+# to do the same for the frontend.
+ENV \
+    HOME=/home/node \
+    KADY_PROJECTS_ROOT=/data/projects \
+    KADY_PI_AGENT_DIR=/data/config \
+    KADY_SKILLS_CACHE_DIR=/data/config/skills-cache \
+    KADY_HOST=0.0.0.0 \
+    HOSTNAME=0.0.0.0
+
+# Data dirs + writable app dir. Owned by `node` (uid 1000); the entrypoint
+# re-fixes bind-mount ownership at runtime and drops privileges to node.
+RUN mkdir -p /data/projects /data/config/skills-cache \
+    && chown -R node:node /data /app
+
+EXPOSE 3000 8000
+
+COPY docker-entrypoint.sh /usr/local/bin/kady-entrypoint
+RUN chmod +x /usr/local/bin/kady-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/kady-entrypoint"]
+# Matches `./start.sh` but without trying to open a host browser. Installs the
+# pinned harness, preps projects/skills, frees ports, starts both services.
+CMD ["node", "start.mjs", "--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,26 +46,9 @@ RUN set -eux; \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
-# ---- Dependencies (layer-cached ahead of source) -----------------------------
-WORKDIR /app
-
-COPY web/package.json web/package-lock.json ./web/
-RUN cd web && npm ci --no-audit --no-fund
-
-COPY server/package.json server/package-lock.json ./server/
-RUN cd server && npm ci --no-audit --no-fund
-
-# ---- Source ------------------------------------------------------------------
-COPY . .
-
-# Bake the scientific helper venv (numpy/anndata/rdkit/…) at build time.
-RUN cd server/src/helpers && uv sync
-
-# Empty root .env stops start.mjs from copying .env.example over compose keys.
-RUN touch /app/.env
-
-# ---- Runtime -----------------------------------------------------------------
-# Listen on all interfaces inside the container; compose still publishes
+# ---- Environment -------------------------------------------------------------
+# Set before the build steps, not just for runtime: npm and uv key their caches
+# off HOME. Listening on 0.0.0.0 is container-internal; compose still publishes
 # 127.0.0.1 only. HOSTNAME=0.0.0.0 does the same for `next dev`.
 ENV \
     HOME=/home/node \
@@ -75,12 +58,42 @@ ENV \
     KADY_HOST=0.0.0.0 \
     HOSTNAME=0.0.0.0
 
-# Owned by node; the entrypoint re-fixes bind-mounts and drops to node.
-RUN mkdir -p /data/projects /data/config/skills-cache \
-    && chown -R node:node /data /app
+# Built as `node` throughout, into dirs it already owns. Chowning /app after
+# the fact instead costs a 2.2 GB layer: chown rewrites metadata on every file,
+# so Docker copies node_modules and the uv venv into a fresh layer.
+RUN mkdir -p /app /data/projects /data/config/skills-cache \
+    && chown -R node:node /app /data
+USER node
 
+# ---- Dependencies (layer-cached ahead of source) -----------------------------
+WORKDIR /app
+
+# Cache mounts keep npm's and uv's caches out of the image (~1.2 GB of bytes
+# nothing at runtime reads) while still making rebuilds fast.
+COPY --chown=node:node web/package.json web/package-lock.json ./web/
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
+    cd web && npm ci --no-audit --no-fund
+
+COPY --chown=node:node server/package.json server/package-lock.json ./server/
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
+    cd server && npm ci --no-audit --no-fund
+
+# ---- Source ------------------------------------------------------------------
+COPY --chown=node:node . .
+
+# Bake the scientific helper venv (numpy/anndata/rdkit/…) at build time.
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.cache/uv \
+    cd server/src/helpers && uv sync
+
+# Empty root .env stops start.mjs from copying .env.example over compose keys.
+RUN touch /app/.env
+
+# ---- Runtime -----------------------------------------------------------------
 EXPOSE 3000 8000
 
+# Back to root only for the entrypoint, which must start privileged to chown
+# bind-mounted volumes before setpriv drops back to node.
+USER root
 COPY docker-entrypoint.sh /usr/local/bin/kady-entrypoint
 RUN chmod +x /usr/local/bin/kady-entrypoint
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ That's it. Create a project, drop in your data, and ask Kady for what you want �
 
 ➡️ **Step-by-step details, optional API keys, and troubleshooting:** [Installation guide](./docs/installation.md)
 ➡️ **Your first session and everyday features:** [Basic usage](./docs/basic-usage.md)
+➡️ **Prefer a container? Run Kady with Docker** — one command, isolated agent sandbox, local models reached by base URL (Ollama/llama.cpp/LM Studio), LaTeX optional: [Docker guide](./docs/docker.md)
 ➡️ **Prefer to watch first?** [Tutorial videos](#tutorial-videos)
 
 ## Tutorial videos
@@ -155,6 +156,7 @@ All guides live in the [`docs/`](./docs) folder:
 |-------|----------------|
 | [Codebase summary](./docs/codebase-summary.md) | One-page overview of what K-Dense BYOK is, what it can do, and why it matters |
 | [Installation](./docs/installation.md) | Full setup walkthrough, subscriptions, optional API keys, updating, troubleshooting |
+| [Docker](./docs/docker.md) | Run Kady in a container — one command, isolated agent sandbox, local models by base URL, LaTeX optional |
 | [Basic usage](./docs/basic-usage.md) | First session, chat tabs, files, workflows, databases, costs, tips |
 | [File previews](./docs/file-previews.md) | Every scientific format Kady can render — structures, spectra, imaging, arrays, and more |
 | [Living Lab Notebook](./docs/lab-notebook.md) | Real-time record of Kady's work — structured entries, export, and PDF |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,6 @@
-# Kady — single-container Docker Compose setup.
-#
-# Runs BOTH services (backend :8000, frontend :3000) in one container,
-# exactly as `./start.sh` starts them on a host. Local models (Ollama,
-# llama.cpp, LM Studio, vLLM, …) are NOT bundled here — you run them yourself
-# and Kady just points at their base URL, which is the usual pattern.
-# By default Kady reaches those servers on the HOST via `host.docker.internal`
-# (see OLLAMA_BASE_URL / OPENAI_COMPATIBLE_BASE_URL below); override them in
-# your .env to point anywhere else.
+# Kady — single container running both services (backend :8000, frontend :3000)
+# as `./start.sh` does. Local models are not bundled; Kady just points at their
+# base URL, reaching the host via `host.docker.internal` unless you override in .env.
 
 services:
   kady:
@@ -15,45 +9,34 @@ services:
       # --build-arg equivalent. Set WITH_LATEX=0 in your shell/.env to build a
       # smaller image without TeX Live (LaTeX compile + SyncTeX disabled).
       args:
+        # Set WITH_LATEX=0 in your shell/.env for a smaller image without TeX.
         WITH_LATEX: ${WITH_LATEX:-1}
     image: kady:${KADY_TAG:-latest}
     container_name: kady
-    # Host ports bound to 127.0.0.1 only — a local research app should not be
-    # reachable from the LAN. To expose it (e.g. to a LAN client), change the
-    # prefix to 0.0.0.0 or your host's LAN IP; to reach it over SSH, tunnel it.
+    # Localhost-only; change the prefix to expose on the LAN.
     ports:
       - "127.0.0.1:${KADY_UI_PORT:-3000}:3000"
       - "127.0.0.1:${KADY_API_PORT:-8000}:8000"
-    # Optional: load your API keys from .env. `required: false` lets you start
-    # with no .env at all (and set keys later in Settings → API keys).
+    # Optional API keys; required:false lets you start with no .env.
     env_file:
       - path: .env
         required: false
     environment:
-      # Local model servers live on the HOST; `host.docker.internal` is the
-      # alias Docker gives the host from inside the container. Override these
-      # in .env to point elsewhere, e.g. a remote machine or a LAN server.
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      # llama.cpp (`llama-server`), LM Studio, vLLM, etc. expose an
-      # OpenAI-compatible API; OPENAI_COMPATIBLE_CONFIGURED=1 shows the
-      # picker section even before a server answers on the default port.
+      # =1 keeps the picker section visible even before a server answers.
       OPENAI_COMPATIBLE_BASE_URL: ${OPENAI_COMPATIBLE_BASE_URL:-http://host.docker.internal:1234}
       OPENAI_COMPATIBLE_CONFIGURED: ${OPENAI_COMPATIBLE_CONFIGURED:-1}
-      # Persistent user data lives here (inside the container).
+      # Must match the server's real context (llama.cpp --ctx-size).
+      OPENAI_COMPATIBLE_CONTEXT_WINDOW: ${OPENAI_COMPATIBLE_CONTEXT_WINDOW:-32768}
       KADY_PROJECTS_ROOT: /data/projects
-      # Pi auth/settings/skills-cache persist here.
       KADY_PI_AGENT_DIR: /data/config
       KADY_SKILLS_CACHE_DIR: /data/config/skills-cache
-    # Lets the container reach the host for OLLAMA_BASE_URL /
-    # OPENAI_COMPATIBLE_BASE_URL on Linux (Docker Desktop does this already).
+    # Let the container reach the host (needed on Linux; Desktop does it already).
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      # Your projects (chat sessions, sandbox files, provenance, …).
       - ./projects:/data/projects
-      # OAuth tokens (auth.json), Pi settings, and the skills cache survive
-      # container rebuilds. It's a named volume so perms are handled for you.
-      - kady-config:/data/config
+      - kady-config:/data/config  # auth, settings, skills cache (survive rebuilds)
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       # =1 keeps the picker section visible even before a server answers.
       OPENAI_COMPATIBLE_BASE_URL: ${OPENAI_COMPATIBLE_BASE_URL:-http://host.docker.internal:1234}
       OPENAI_COMPATIBLE_CONFIGURED: ${OPENAI_COMPATIBLE_CONFIGURED:-1}
-      # Must match the server's real context (llama.cpp --ctx-size).
+      # Fallback only — the real window is read from /v1/models per model.
+      # Set it for servers that don't report one (LM Studio, unloaded models).
       OPENAI_COMPATIBLE_CONTEXT_WINDOW: ${OPENAI_COMPATIBLE_CONTEXT_WINDOW:-32768}
       KADY_PROJECTS_ROOT: /data/projects
       KADY_PI_AGENT_DIR: /data/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+# Kady — single-container Docker Compose setup.
+#
+# Runs BOTH services (backend :8000, frontend :3000) in one container,
+# exactly as `./start.sh` starts them on a host. Local models (Ollama,
+# llama.cpp, LM Studio, vLLM, …) are NOT bundled here — you run them yourself
+# and Kady just points at their base URL, which is the usual pattern.
+# By default Kady reaches those servers on the HOST via `host.docker.internal`
+# (see OLLAMA_BASE_URL / OPENAI_COMPATIBLE_BASE_URL below); override them in
+# your .env to point anywhere else.
+
+services:
+  kady:
+    build:
+      context: .
+      # --build-arg equivalent. Set WITH_LATEX=0 in your shell/.env to build a
+      # smaller image without TeX Live (LaTeX compile + SyncTeX disabled).
+      args:
+        WITH_LATEX: ${WITH_LATEX:-1}
+    image: kady:${KADY_TAG:-latest}
+    container_name: kady
+    # Host ports bound to 127.0.0.1 only — a local research app should not be
+    # reachable from the LAN. To expose it (e.g. to a LAN client), change the
+    # prefix to 0.0.0.0 or your host's LAN IP; to reach it over SSH, tunnel it.
+    ports:
+      - "127.0.0.1:${KADY_UI_PORT:-3000}:3000"
+      - "127.0.0.1:${KADY_API_PORT:-8000}:8000"
+    # Optional: load your API keys from .env. `required: false` lets you start
+    # with no .env at all (and set keys later in Settings → API keys).
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      # Local model servers live on the HOST; `host.docker.internal` is the
+      # alias Docker gives the host from inside the container. Override these
+      # in .env to point elsewhere, e.g. a remote machine or a LAN server.
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      # llama.cpp (`llama-server`), LM Studio, vLLM, etc. expose an
+      # OpenAI-compatible API; OPENAI_COMPATIBLE_CONFIGURED=1 shows the
+      # picker section even before a server answers on the default port.
+      OPENAI_COMPATIBLE_BASE_URL: ${OPENAI_COMPATIBLE_BASE_URL:-http://host.docker.internal:1234}
+      OPENAI_COMPATIBLE_CONFIGURED: ${OPENAI_COMPATIBLE_CONFIGURED:-1}
+      # Persistent user data lives here (inside the container).
+      KADY_PROJECTS_ROOT: /data/projects
+      # Pi auth/settings/skills-cache persist here.
+      KADY_PI_AGENT_DIR: /data/config
+      KADY_SKILLS_CACHE_DIR: /data/config/skills-cache
+    # Lets the container reach the host for OLLAMA_BASE_URL /
+    # OPENAI_COMPATIBLE_BASE_URL on Linux (Docker Desktop does this already).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      # Your projects (chat sessions, sandbox files, provenance, …).
+      - ./projects:/data/projects
+      # OAuth tokens (auth.json), Pi settings, and the skills cache survive
+      # container rebuilds. It's a named volume so perms are handled for you.
+      - kady-config:/data/config
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 120s
+
+volumes:
+  kady-config:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Kady container entrypoint.
+#
+# Default (`docker compose up`): runs `node start.mjs --no-browser`, which
+# installs the pinned harness, preps projects + skills, frees the ports, and
+# starts BOTH services (backend + frontend), forwarding SIGTERM/SIGINT so the
+# container stops cleanly.
+#
+# If run as root (the default), it fixes ownership of the mounted data dirs —
+# this is what lets you bind-mount `./projects` without manual chown'ing on
+# Linux — then DROPS privileges to the `node` user so the agent's bash/python
+# sandbox never runs as root, before exec'ing the command.
+#
+# Override the command to run a one-off, e.g.:
+#   docker compose run --rm kady sh -c "npm --prefix server run prep"
+set -eu
+
+data_dirs="${KADY_PROJECTS_ROOT} ${KADY_PI_AGENT_DIR} ${KADY_SKILLS_CACHE_DIR}"
+
+if [ "$(id -u)" = "0" ]; then
+  # shellcheck disable=SC2086
+  mkdir -p ${data_dirs}
+  # shellcheck disable=SC2086
+  chown -R node:node ${data_dirs}
+  exec setpriv --reuid=node --regid=node --clear-groups "$@"
+fi
+
+# shellcheck disable=SC2086
+mkdir -p ${data_dirs}
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env sh
-# Kady container entrypoint.
-#
-# Default (`docker compose up`): runs `node start.mjs --no-browser`, which
-# installs the pinned harness, preps projects + skills, frees the ports, and
-# starts BOTH services (backend + frontend), forwarding SIGTERM/SIGINT so the
-# container stops cleanly.
-#
-# If run as root (the default), it fixes ownership of the mounted data dirs —
-# this is what lets you bind-mount `./projects` without manual chown'ing on
-# Linux — then DROPS privileges to the `node` user so the agent's bash/python
-# sandbox never runs as root, before exec'ing the command.
-#
-# Override the command to run a one-off, e.g.:
-#   docker compose run --rm kady sh -c "npm --prefix server run prep"
+# Runs `node start.mjs --no-browser` (both services) by default; override the
+# command for one-offs, e.g. `docker compose run --rm kady npm --prefix server run prep`.
+# When root, fixes bind-mount ownership then drops to the `node` user.
 set -eu
 
 data_dirs="${KADY_PROJECTS_ROOT} ${KADY_PI_AGENT_DIR} ${KADY_SKILLS_CACHE_DIR}"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -91,6 +91,14 @@ Leave off the `/v1`.
 picker's "Local (OpenAI-compatible)" section visible even before a server is
 running, so you can point it at a to-be-started endpoint.
 
+> **Match the context window to the server.** Kady defaults to declaring a
+> 32K window for local models. If you serve a model with a larger context
+> (llama.cpp `--ctx-size`, e.g. `131072`), set `OPENAI_COMPATIBLE_CONTEXT_WINDOW`
+> to match. Otherwise, once the system prompt + tool schemas push the prompt
+> past 32K, Pi reserves almost no output tokens and every run comes back empty
+> (the request shows `max_completion_tokens: 1`).
+> `OPENAI_COMPATIBLE_CONTEXT_WINDOW=131072`
+
 ### Why not bundle Ollama/llama.cpp in the image?
 
 - **Separation of concerns** — the model server and the app have different

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,7 +39,7 @@ Then open **http://localhost:3000** in your browser.
 ```bash
 docker compose logs -f kady     # watch startup / runtime logs
 docker compose down             # stop (data persists)
-docker compose build --build-arg WITH_LATEX=0 -t kady:lite .   # smaller image
+WITH_LATEX=0 KADY_TAG=lite docker compose build   # smaller image (no TeX)
 docker compose run --rm kady sh -c "npm --prefix server run prep"   # re-seed
 docker compose run --rm kady sh -c "npm --prefix server run test"   # tests
 ```
@@ -137,8 +137,9 @@ compile returns a clean *"LaTeX compiler not found"* result and SyncTeX reports
 **build-time** choice:
 
 ```bash
-docker compose build --build-arg WITH_LATEX=1 -t kady:latest   # LaTeX ON (default)
-docker compose build --build-arg WITH_LATEX=0 -t kady:lite     # LaTeX OFF (~0.5GB smaller)
+docker compose build                                  # LaTeX ON (default, tags kady:latest)
+WITH_LATEX=0 KADY_TAG=lite docker compose build       # LaTeX OFF (~0.5GB smaller)
+# or: docker build --build-arg WITH_LATEX=0 -t kady:lite .
 ```
 
 Honest trade-off: the image is ~5.2GB even without TeX, because the scientific

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,219 @@
+# Running Kady with Docker
+
+Kady ships an optional single-container setup. It runs **both** services — the
+TS backend (Pi agent, port `8000`) and the Next.js frontend (port `3000`) —
+exactly as `./start.sh` starts them on a host, but inside one isolated
+container. That isolation is the point: the agent's `bash`/Python/LaTeX
+sandbox becomes an **OS-level boundary**, so agent tools never run as your OS
+user and can't reach your host's files, keys, or (crucially) the Docker socket.
+
+- `Dockerfile` — builds the image (LaTeX optional, see below).
+- `docker-compose.yml` — the recommended way to run it.
+- `docker-entrypoint.sh` — fixes data-volume ownership, drops privileges to a
+  non-root `node` user, then starts both services.
+
+> **Local models are NOT bundled.** This follows the usual pattern: you run
+> Ollama / llama.cpp / LM Studio / vLLM yourself, and Kady just points at their
+> base URL via environment variables. See [Local models](#local-models).
+
+---
+
+## Quick start
+
+```bash
+cp .env.example .env          # optional, but where you put API keys
+docker compose up -d          # build (first time) + start
+```
+
+Then open **http://localhost:3000** in your browser.
+
+- Add hosted-model keys (`OPENROUTER_API_KEY`, etc.) in `.env` or later in
+  **Settings → API keys**.
+- Your data (projects, chat sessions, sandbox, provenance) persists in
+  `./projects/` on the host (bind-mounted).
+- OAuth tokens (Pi subscription auth), Pi settings, and the skills cache
+  persist in the `kady-config` named volume — safe across rebuilds.
+
+### Useful commands
+
+```bash
+docker compose logs -f kady     # watch startup / runtime logs
+docker compose down             # stop (data persists)
+docker compose build --build-arg WITH_LATEX=0 -t kady:lite .   # smaller image
+docker compose run --rm kady sh -c "npm --prefix server run prep"   # re-seed
+docker compose run --rm kady sh -c "npm --prefix server run test"   # tests
+```
+
+---
+
+## Local models
+
+Two conventions cover essentially any local model server; both run on the
+**host** and are reached through `host.docker.internal` (the alias Docker gives
+the host from inside a container — wired automatically in `docker-compose.yml`
+via `extra_hosts`, and already present on Docker Desktop).
+
+### Ollama
+
+```bash
+ollama serve                    # on your host
+ollama pull llama3
+```
+
+The compose file defaults `OLLAMA_BASE_URL=http://host.docker.internal:11434`,
+so Ollama models already appear in the picker as `ollama/<model>`. Override in
+`.env` to point anywhere else (a LAN server, another host, …):
+
+```dotenv
+OLLAMA_BASE_URL=http://my-server:11434
+```
+
+### llama.cpp (and any OpenAI-compatible server)
+
+`llama-server`, LM Studio, vLLM, text-generation-webui, etc. all expose the
+standard `/v1/chat/completions` + `/v1/models` API. Point Kady at it:
+
+```dotenv
+# llama.cpp on the host:
+OPENAI_COMPATIBLE_BASE_URL=http://host.docker.internal:8080
+# (adjust the port to whatever you passed `llama-server --port`, e.g. 8080)
+
+# Any other host/LAN server:
+OPENAI_COMPATIBLE_BASE_URL=http://192.168.1.20:8085
+```
+
+> **Use the ROOT, not the `/v1` path.** Kady appends `/v1/models` itself, so if
+you set `OPENAI_COMPATIBLE_BASE_URL=http://host:8085/v1` it will call
+`http://host:8085/v1/v1/models` and the model list comes back **not running**.
+Leave off the `/v1`.
+
+`OPENAI_COMPATIBLE_CONFIGURED=1` (set by default in the compose file) keeps the
+picker's "Local (OpenAI-compatible)" section visible even before a server is
+running, so you can point it at a to-be-started endpoint.
+
+### Why not bundle Ollama/llama.cpp in the image?
+
+- **Separation of concerns** — the model server and the app have different
+  update cycles, GPU needs, and storage profiles.
+- **GPU availability** — local-model servers are the thing that actually wants
+  the GPU. Keeping them on the host avoids Docker GPU/Apple-Silicon issues and
+  lets you use them with `start.sh` too.
+- **It's the standard pattern** — pass a base URL, don't embed a second app.
+
+---
+
+## LaTeX: optional by design
+
+The app already treats a missing LaTeX install as a graceful degradation — a
+compile returns a clean *"LaTeX compiler not found"* result and SyncTeX reports
+*unavailable*; nothing crashes. So whether TeX is in the image is purely a
+**build-time** choice:
+
+```bash
+docker compose build --build-arg WITH_LATEX=1 -t kady:latest   # LaTeX ON (default)
+docker compose build --build-arg WITH_LATEX=0 -t kady:lite     # LaTeX OFF (~0.5GB smaller)
+```
+
+Honest trade-off: the image is ~5.2GB even without TeX, because the scientific
+file-preview helper venv (anndata/rdkit/scipy/matplotlib/…) and `node_modules`
+dominate. LaTeX adds ~500MB. So `lite` is smaller, but not dramatically — its
+main value is dropping a dependency you'll never use.
+
+- `latest` (LaTeX): full LaTeX editing, compile, and source↔PDF SyncTeX sync.
+- `lite` (no LaTeX): everything else identical; LaTeX compile + SyncTeX are the
+  only disabled features.
+
+---
+
+## Authentication (subscription OAuth) — no tunnel needed
+
+Kady's subscription login (OpenAI Codex / Claude / Copilot / xAI in
+**Settings → Model providers**) is **headless-friendly by design**. It never
+needs a browser on the same machine as the server or a `localhost` redirect
+callback; it presents you with one of:
+
+- an **`auth_url`** to open in your own browser,
+- a **`device_code`** to enter at the provider's verification URL, or
+- a **`manual_code`** to paste back into Settings.
+
+All three complete in *your* browser, wherever it is; the container just holds
+the resulting tokens in `KADY_PI_AGENT_DIR/auth.json` (persisted in the
+`kady-config` volume). So on a same-machine Docker setup, subscription OAuth
+works with **zero port-forwarding** — click Connect, follow the URL/code
+prompt in your normal browser.
+
+API-key providers (OpenRouter, NVIDIA NIM) and local models work with no OAuth
+at all.
+
+---
+
+## Running on a remote/headless host (SSH)
+
+If the container runs on a remote machine (a VM, a server, an old laptop), reach
+the UI with a plain SSH tunnel and complete OAuth in your local browser:
+
+```bash
+# from your laptop — forward the remote UI (3000) and API (8000) ports
+ssh -L 3000:localhost:3000 -L 8000:localhost:8000 user@kady-host
+```
+
+Then open `http://localhost:3000`. Because compose binds the host ports to
+`127.0.0.1`, nothing is exposed to the LAN — the only way in is this tunnel.
+(This same forward would even carry a hypothetical `localhost` OAuth callback,
+since the API port is tunnelled too.)
+
+> Want LAN clients instead of a tunnel? Change the compose `ports` prefix from
+> `127.0.0.1:...` to `0.0.0.0:...` or a specific host IP. Prefer the tunnel for
+> anything not fully trusted.
+
+---
+
+## Security notes
+
+- **Non-root everywhere.** `docker-entrypoint.sh` runs as root only long enough
+  to fix volume ownership, then `setpriv`s down to the `node` user (uid 1000).
+  PID 1 and every agent/worker process run as uid 1000 — the agent shell never
+  has root inside the container.
+- **No Docker socket.** The image mounts **no** `/var/run/docker.sock`. That's
+  what keeps the container an actual boundary: a compromised agent can't reach
+  your host.
+- **Host ports are localhost-bound** by default (see `docker-compose.yml`).
+- **Config stays external.** `.env`, `auth.json`, and the projects volume never
+  enter the image (see `.dockerignore` and the `docker-entrypoint.sh` env
+  handling).
+
+---
+
+## Layout & persistence
+
+| Path (host)            | In container        | What lives there |
+|------------------------|---------------------|------------------|
+| `./projects/` (bind)   | `/data/projects`    | projects, chat sessions, sandbox, provenance, Modal jobs |
+| `kady-config` (volume) | `/data/config`      | Pi OAuth `auth.json`, Pi settings, skills cache |
+
+The `docker-entrypoint.sh` ensures `/data/projects` and `/data/config` are
+created and owned by `node`, so bind-mounts work on Linux without manual
+`chown`. Skills for the default project are seeded on first boot (`npm run prep`
+inside `start.mjs`).
+
+---
+
+## Known limitations
+
+- **Image size ~5.2–5.7GB** — dominated by `node_modules` and the scientific
+  helper venv, not LaTeX. A leaner "production" variant (Next.js production
+  build + runtime-only deps) is a planned follow-up.
+- **Dev servers by default.** The image starts `next dev` + `tsx` — same as
+  `./start.sh`, so parity and hot-reload hold, at the cost of dev-server
+  overhead. A production profile is planned.
+- **No GPU inside the container** on Apple Silicon; run Ollama/llama.cpp on the
+  host (the default setup) and Kady reaches them over `host.docker.internal`.
+- **First boot** runs `npm run prep`, which syncs the K-Dense scientific skills
+  catalogue and the per-project sandbox venv — allow a minute or two.
+
+## Files
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `docker-entrypoint.sh`
+- `.dockerignore`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -91,13 +91,32 @@ Leave off the `/v1`.
 picker's "Local (OpenAI-compatible)" section visible even before a server is
 running, so you can point it at a to-be-started endpoint.
 
-> **Match the context window to the server.** Kady defaults to declaring a
-> 32K window for local models. If you serve a model with a larger context
-> (llama.cpp `--ctx-size`, e.g. `131072`), set `OPENAI_COMPATIBLE_CONTEXT_WINDOW`
-> to match. Otherwise, once the system prompt + tool schemas push the prompt
-> past 32K, Pi reserves almost no output tokens and every run comes back empty
-> (the request shows `max_completion_tokens: 1`).
-> `OPENAI_COMPATIBLE_CONTEXT_WINDOW=131072`
+#### Context windows are detected automatically
+
+Kady reads each model's real context window off the same `/v1/models` listing
+it uses to populate the picker — `meta.n_ctx` on llama.cpp (the served
+`--ctx-size`), `max_model_len` on vLLM. A `llama-server` started with
+`--ctx-size 131072` is declared as 131072 with no configuration, and an 8K
+embedding model served alongside it is declared as 8192. You do not normally
+need to set anything.
+
+This matters because a wrong window fails quietly: declare one *smaller* than
+the prompt and Pi reserves almost no output tokens, so every run comes back
+empty (the request shows `max_completion_tokens: 1`); declare one *larger* than
+the server allocated and the server truncates or rejects.
+
+Detection only works for models the server has actually **loaded** — a
+llama.cpp router lists every configured preset but reports `meta` only for live
+instances — and LM Studio reports context on its own `/api/v0/models` rather
+than the OpenAI-compatible route. For those cases, set the fallback:
+
+```dotenv
+OPENAI_COMPATIBLE_CONTEXT_WINDOW=131072
+```
+
+It applies only where nothing was detected; a window read from the server
+always wins, since one global number cannot be right for every model a server
+hosts.
 
 ### Why not bundle Ollama/llama.cpp in the image?
 

--- a/server/src/agent/models.ts
+++ b/server/src/agent/models.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_MODEL_PROVIDER,
   OLLAMA_BASE_URL,
   OPENAI_COMPATIBLE_BASE_URL,
+  OPENAI_COMPATIBLE_CONTEXT_WINDOW,
   REPO_ROOT,
 } from "../config.ts";
 import { isSubscriptionProvider, subscriptionProvider } from "./provider-auth.ts";
@@ -258,7 +259,9 @@ export function buildOpenAICompatibleModel(name: string): Model<Api> {
     reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 32_768,
+    // Must track the local server's real context (llama.cpp --ctx-size), or
+    // Pi reserves almost no output tokens once the prompt approaches 32K.
+    contextWindow: OPENAI_COMPATIBLE_CONTEXT_WINDOW,
     maxTokens: 8192,
   };
 }

--- a/server/src/agent/models.ts
+++ b/server/src/agent/models.ts
@@ -27,12 +27,15 @@ import {
   DEFAULT_MODEL_PROVIDER,
   OLLAMA_BASE_URL,
   OPENAI_COMPATIBLE_BASE_URL,
-  OPENAI_COMPATIBLE_CONTEXT_WINDOW,
   REPO_ROOT,
 } from "../config.ts";
 import { isSubscriptionProvider, subscriptionProvider } from "./provider-auth.ts";
 import { customProviderName, isCustomProvider } from "./custom-models.ts";
 import { directProvider, isDirectProvider } from "./provider-catalog.ts";
+import {
+  openAICompatibleContextWindow,
+  warmOpenAICompatibleContextWindows,
+} from "./openai-compatible-context.ts";
 
 // OpenRouter's base URL. Overridable via OPENROUTER_BASE_URL so the
 // OpenAI-compatible provider can point at any compatible gateway — e.g.
@@ -245,9 +248,12 @@ function buildOllamaModel(name: string): Model<Api> {
  * path to buildOllamaModel rather than a shared base — the two only look alike
  * because both endpoints happen to be OpenAI-shaped.
  *
- * `/v1/models` carries no pricing or context length anywhere near reliably, so
- * this uses the same $0 / 32K defaults Ollama does. $0 is honest here only
- * because the provider is local-only; see `billingForProvider`.
+ * `/v1/models` carries no pricing, so this uses the same $0 default Ollama
+ * does. $0 is honest here only because the provider is local-only; see
+ * `billingForProvider`.
+ *
+ * The context window is read back from the server's own listing — see
+ * `openai-compatible-context.ts`.
  */
 export function buildOpenAICompatibleModel(name: string): Model<Api> {
   return {
@@ -259,9 +265,7 @@ export function buildOpenAICompatibleModel(name: string): Model<Api> {
     reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    // Must track the local server's real context (llama.cpp --ctx-size), or
-    // Pi reserves almost no output tokens once the prompt approaches 32K.
-    contextWindow: OPENAI_COMPATIBLE_CONTEXT_WINDOW,
+    contextWindow: openAICompatibleContextWindow(name),
     maxTokens: 8192,
   };
 }
@@ -323,6 +327,10 @@ export async function setupModelRuntime(modelRuntime: ModelRuntime): Promise<voi
   // Pi reads every direct provider's key straight from process.env (loaded
   // from .env by env.ts), so only OpenRouter needs a push here — its legacy
   // OR_API_KEY alias is unknown to Pi.
+  // Warm the openai-compatible context-window cache from `/v1/models` (not
+  // awaited: startup must not block on a server that may not be running).
+  void warmOpenAICompatibleContextWindows();
+
   const orKey = process.env.OPENROUTER_API_KEY || process.env.OR_API_KEY;
   if (orKey) await modelRuntime.setRuntimeApiKey("openrouter", orKey);
 }

--- a/server/src/agent/models.ts
+++ b/server/src/agent/models.ts
@@ -327,9 +327,14 @@ export async function setupModelRuntime(modelRuntime: ModelRuntime): Promise<voi
   // Pi reads every direct provider's key straight from process.env (loaded
   // from .env by env.ts), so only OpenRouter needs a push here — its legacy
   // OR_API_KEY alias is unknown to Pi.
-  // Warm the openai-compatible context-window cache from `/v1/models` (not
-  // awaited: startup must not block on a server that may not be running).
-  void warmOpenAICompatibleContextWindows();
+  //
+  // Warm the openai-compatible context-window cache from `/v1/models` before
+  // any model can be resolved. Awaited: a restored session can resolve its
+  // model immediately after this returns, and a fire-and-forget warm races
+  // that (fallback 32K → empty replies). The fetch times out at 2s, so a
+  // missing server does not stall boot.
+  await warmOpenAICompatibleContextWindows();
+
 
   const orKey = process.env.OPENROUTER_API_KEY || process.env.OR_API_KEY;
   if (orKey) await modelRuntime.setRuntimeApiKey("openrouter", orKey);

--- a/server/src/agent/openai-compatible-context.ts
+++ b/server/src/agent/openai-compatible-context.ts
@@ -74,26 +74,35 @@ export function openAICompatibleContextWindow(id: string): number {
   return discovered.get(id) ?? OPENAI_COMPATIBLE_CONTEXT_WINDOW;
 }
 
+/** In-flight / completed warm. Coalesces concurrent callers. */
+let warming: Promise<void> | undefined;
+
 /**
  * Warm the cache at startup so a model ref restored from a saved session is
  * sized correctly even if nobody opened the picker. Failure-tolerant: having no
- * local server is the common case, and the default covers it.
+ * local server is the common case, and the default covers it. Callers that need
+ * the window before a model is built (setupModelRuntime) must await this — the
+ * 2s timeout already bounds the wait.
  */
-export async function warmOpenAICompatibleContextWindows(): Promise<void> {
-  try {
-    const resp = await fetch(
-      `${OPENAI_COMPATIBLE_BASE_URL.replace(/\/+$/, "")}/v1/models`,
-      { signal: AbortSignal.timeout(2000) },
-    );
-    if (!resp.ok) return;
-    const data = (await resp.json()) as { data?: unknown };
-    noteOpenAICompatibleModels(Array.isArray(data.data) ? data.data : []);
-  } catch {
-    // No server, or one that doesn't answer in time. Defaults apply.
-  }
+export function warmOpenAICompatibleContextWindows(): Promise<void> {
+  warming ??= (async () => {
+    try {
+      const resp = await fetch(
+        `${OPENAI_COMPATIBLE_BASE_URL.replace(/\/+$/, "")}/v1/models`,
+        { signal: AbortSignal.timeout(2000) },
+      );
+      if (!resp.ok) return;
+      const data = (await resp.json()) as { data?: unknown };
+      noteOpenAICompatibleModels(Array.isArray(data.data) ? data.data : []);
+    } catch {
+      // No server, or one that doesn't answer in time. Defaults apply.
+    }
+  })();
+  return warming;
 }
 
 /** Test seam. */
 export function resetOpenAICompatibleContextWindows(): void {
   discovered.clear();
+  warming = undefined;
 }

--- a/server/src/agent/openai-compatible-context.ts
+++ b/server/src/agent/openai-compatible-context.ts
@@ -1,0 +1,99 @@
+/**
+ * Context-window discovery for local OpenAI-compatible servers.
+ *
+ * Pi sizes its output-token reserve from the model's context window, and a
+ * wrong value fails quietly in both directions: too small and every run comes
+ * back empty (`max_completion_tokens: 1`), too large and the server truncates.
+ * One hardcoded default cannot serve a 128K chat model and an 8K embedding
+ * model on the same host, so read it off the `/v1/models` listing the picker
+ * already fetches — `meta.n_ctx` on llama.cpp, `max_model_len` on vLLM.
+ *
+ * Not used: llama.cpp's `meta.n_ctx_train` (the model's trained context, not
+ * what the server allocated — off by 8x on a 1M-trained model served at 128K)
+ * and `/props` (returns `n_ctx: 0` in router mode).
+ */
+import {
+  OPENAI_COMPATIBLE_BASE_URL,
+  OPENAI_COMPATIBLE_CONTEXT_WINDOW,
+} from "../config.ts";
+
+/**
+ * model id -> window reported by the server. Only loaded models appear: a
+ * llama.cpp router lists every preset but annotates only live instances, so
+ * misses are normal and fall back to the configured default.
+ */
+const discovered = new Map<string, number>();
+
+/** Sanity bounds. Anything outside is a malformed field, not a real window. */
+const MIN_WINDOW = 1_024;
+const MAX_WINDOW = 100_000_000;
+
+/** The served window from one `/v1/models` entry, if the server reported one. */
+export function contextWindowFromModelEntry(entry: unknown): number | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const e = entry as { max_model_len?: unknown; meta?: unknown };
+  // vLLM.
+  const vllm = toWindow(e.max_model_len);
+  if (vllm !== undefined) return vllm;
+  // llama.cpp. `n_ctx` only — see the note on n_ctx_train above.
+  const meta = e.meta;
+  if (meta && typeof meta === "object") {
+    return toWindow((meta as { n_ctx?: unknown }).n_ctx);
+  }
+  return undefined;
+}
+
+function toWindow(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const n = Math.floor(value);
+  return n >= MIN_WINDOW && n <= MAX_WINDOW ? n : undefined;
+}
+
+/**
+ * Record what a listing reported. Unannotated entries are left alone rather
+ * than cleared: an unloaded model still serves at the same context on demand,
+ * so the last known value beats reverting to a guess.
+ */
+export function noteOpenAICompatibleModels(entries: readonly unknown[]): void {
+  for (const entry of entries) {
+    const id = (entry as { id?: unknown })?.id;
+    if (typeof id !== "string" || !id.trim()) continue;
+    const window = contextWindowFromModelEntry(entry);
+    if (window !== undefined) discovered.set(id, window);
+  }
+}
+
+/**
+ * Discovery beats OPENAI_COMPATIBLE_CONTEXT_WINDOW: the env var is one global
+ * number, so preferring it over a per-model value read from the server would
+ * reintroduce the mismatch it exists to fix. It stays the fallback for models
+ * the server hasn't loaded, and for LM Studio (which reports context only on
+ * its non-standard `/api/v0/models`).
+ */
+export function openAICompatibleContextWindow(id: string): number {
+  return discovered.get(id) ?? OPENAI_COMPATIBLE_CONTEXT_WINDOW;
+}
+
+/**
+ * Warm the cache at startup so a model ref restored from a saved session is
+ * sized correctly even if nobody opened the picker. Failure-tolerant: having no
+ * local server is the common case, and the default covers it.
+ */
+export async function warmOpenAICompatibleContextWindows(): Promise<void> {
+  try {
+    const resp = await fetch(
+      `${OPENAI_COMPATIBLE_BASE_URL.replace(/\/+$/, "")}/v1/models`,
+      { signal: AbortSignal.timeout(2000) },
+    );
+    if (!resp.ok) return;
+    const data = (await resp.json()) as { data?: unknown };
+    noteOpenAICompatibleModels(Array.isArray(data.data) ? data.data : []);
+  } catch {
+    // No server, or one that doesn't answer in time. Defaults apply.
+  }
+}
+
+/** Test seam. */
+export function resetOpenAICompatibleContextWindows(): void {
+  discovered.clear();
+}

--- a/server/src/agent/scientific-result.ts
+++ b/server/src/agent/scientific-result.ts
@@ -23,7 +23,14 @@ export const MAX_SCIENTIFIC_RESULT_BYTES = 64 * 1024;
 
 const ShortString = Type.String({ minLength: 1, maxLength: 200 });
 const MediumString = Type.String({ minLength: 1, maxLength: 500 });
-const LongString = Type.String({ minLength: 1, maxLength: 2_000 });
+// No `maxLength`: llama.cpp's JSON-schema -> GBNF converter generates an
+// unparseable grammar for a string with a `maxLength` of exactly 2000 when the
+// field is nested inside an array-of-objects (caption/note/interpretation/
+// message), which fails every tool call with "Failed to initialize samplers:
+// failed to parse grammar". Lengths aren't enforced at the schema level
+// anyway — the 64KB card cap in normalizeCard is the real bound — so drop the
+// upper bound to stay compatible with local llama.cpp servers.
+const LongString = Type.String({ minLength: 1 });
 const PathString = Type.String({ minLength: 1, maxLength: 1_000 });
 const Scalar = Type.Union([
   Type.String({ maxLength: 500 }),
@@ -227,7 +234,7 @@ const CitationSchema = Type.Object(
     ]),
     identifier: MediumString,
     title: Type.Optional(MediumString),
-    url: Type.Optional(Type.String({ minLength: 1, maxLength: 2_000 })),
+    url: Type.Optional(Type.String({ minLength: 1 })), // see LongString: no maxLength for llama.cpp grammar compat
     authors: Type.Optional(Type.Array(ShortString, { maxItems: 20 })),
     year: Type.Optional(Type.Integer({ minimum: 0, maximum: 9999 })),
     note: Type.Optional(LongString),

--- a/server/src/agent/scientific-result.ts
+++ b/server/src/agent/scientific-result.ts
@@ -23,14 +23,11 @@ export const MAX_SCIENTIFIC_RESULT_BYTES = 64 * 1024;
 
 const ShortString = Type.String({ minLength: 1, maxLength: 200 });
 const MediumString = Type.String({ minLength: 1, maxLength: 500 });
-// No `maxLength`: llama.cpp's JSON-schema -> GBNF converter generates an
-// unparseable grammar for a string with a `maxLength` of exactly 2000 when the
-// field is nested inside an array-of-objects (caption/note/interpretation/
-// message), which fails every tool call with "Failed to initialize samplers:
-// failed to parse grammar". Lengths aren't enforced at the schema level
-// anyway — the 64KB card cap in normalizeCard is the real bound — so drop the
-// upper bound to stay compatible with local llama.cpp servers.
-const LongString = Type.String({ minLength: 1 });
+// 2048, not 2000: llama.cpp emits an unparseable grammar for a nested string
+// bounded at exactly 2000 (1999 and 2001 are both fine), failing every tool
+// call with "failed to parse grammar". Keep the bound — it is enforced, and the
+// 64KB cap below is an aggregate guard, not a per-field one.
+const LongString = Type.String({ minLength: 1, maxLength: 2_048 });
 const PathString = Type.String({ minLength: 1, maxLength: 1_000 });
 const Scalar = Type.Union([
   Type.String({ maxLength: 500 }),
@@ -103,13 +100,8 @@ const StatisticalTestSchema = Type.Object(
     adjustedPValue: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
     effectSize: Type.Optional(Type.Number()),
     effectSizeLabel: Type.Optional(ShortString),
-    // A 2-element array rather than Type.Tuple: TypeBox emits tuples in
-    // draft-07 style (`items: [...]` plus `additionalItems`), and
-    // `additionalItems` was removed in JSON Schema draft 2020-12. Anthropic
-    // validates tool schemas against 2020-12 and rejects the whole request
-    // ("input_schema: JSON schema is invalid"), so a tuple anywhere in a tool's
-    // parameters breaks every call on that provider. Both positions are plain
-    // numbers, so nothing is lost.
+    // Not Type.Tuple: TypeBox emits draft-07 `additionalItems`, which draft
+    // 2020-12 removed, and Anthropic rejects the whole tool schema over it.
     confidenceInterval: Type.Optional(
       Type.Array(Type.Number(), { minItems: 2, maxItems: 2 }),
     ),
@@ -234,7 +226,7 @@ const CitationSchema = Type.Object(
     ]),
     identifier: MediumString,
     title: Type.Optional(MediumString),
-    url: Type.Optional(Type.String({ minLength: 1 })), // see LongString: no maxLength for llama.cpp grammar compat
+    url: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
     authors: Type.Optional(Type.Array(ShortString, { maxItems: 20 })),
     year: Type.Optional(Type.Integer({ minimum: 0, maximum: 9999 })),
     note: Type.Optional(LongString),
@@ -268,8 +260,8 @@ const MoleculeCardSchema = Type.Object(
     index: Type.Optional(Type.Integer({ minimum: 0 })),
     name: Type.Optional(ShortString),
     formula: Type.Optional(ShortString),
-    smiles: Type.Optional(Type.String({ minLength: 1, maxLength: 2_000 })),
-    inchi: Type.Optional(Type.String({ minLength: 1, maxLength: 2_000 })),
+    smiles: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
+    inchi: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
     molecularWeight: Type.Optional(Type.Number({ minimum: 0 })),
     atomCount: Type.Optional(Type.Integer({ minimum: 0 })),
     bondCount: Type.Optional(Type.Integer({ minimum: 0 })),
@@ -281,11 +273,9 @@ const MoleculeCardSchema = Type.Object(
 );
 
 /**
- * The stored card envelope: a discriminated union, one branch per kind.
- *
- * This is the shape persisted in the tool-result details and consumed by the
- * frontend (`web/src/lib/scientific-results.ts` mirrors it). It is deliberately
- * NOT the tool's input schema — see ScientificResultParams for why.
+ * The stored card envelope, persisted in the tool-result details and mirrored by
+ * `web/src/lib/scientific-results.ts`. Not the tool's input schema — see
+ * ScientificResultParams.
  */
 export const ScientificResultCardSchema = Type.Union(
   [
@@ -307,24 +297,15 @@ export const ScientificResultCardSchema = Type.Union(
 export type ScientificResultCard = Static<typeof ScientificResultCardSchema>;
 
 /**
- * The tool's INPUT schema: one flat object, with `kind` as the discriminant and
- * every kind-specific field optional.
+ * The tool's INPUT schema: one flat object, `kind` as the discriminant, every
+ * kind-specific field optional.
  *
- * Why not reuse the union above? Pi passes `tool.parameters` to the provider
- * verbatim, and OpenAI-style function calling requires `parameters` to be an
- * object schema with `properties`. A top-level `anyOf` has neither, so on the
- * `openai-completions` API (which is how OpenRouter models are driven here) the
- * model received no property names or types at all: it guessed, sent
- * `schemaVersion: "1"` and JSON-encoded strings for arrays, and every call
- * failed validation. Flattening restores a real schema for the model.
- *
- * The cost is that kind/field agreement is no longer expressed in the schema.
- * It is enforced in `cardFromParams`, which validates the assembled card
- * against that kind's exact branch — so the stored envelope is still guaranteed
- * to satisfy ScientificResultCardSchema.
- *
- * `additionalProperties` is left open on purpose: a stray field is stripped
- * during assembly, which beats failing the call and burning a retry.
+ * Not the union above, because OpenAI-style function calling requires
+ * `parameters` to be an object schema with `properties`. A top-level `anyOf`
+ * has neither, so the model saw no property names at all and every call failed
+ * validation. Kind/field agreement moves to `cardFromParams`, which validates
+ * against that kind's exact branch. `additionalProperties` stays open: a stray
+ * field is stripped during assembly rather than burning a retry.
  */
 export const ScientificResultParams = Type.Object(
   {
@@ -385,8 +366,8 @@ export const ScientificResultParams = Type.Object(
     index: Type.Optional(Type.Integer({ minimum: 0 })),
     name: Type.Optional(ShortString),
     formula: Type.Optional(ShortString),
-    smiles: Type.Optional(Type.String({ minLength: 1, maxLength: 2_000 })),
-    inchi: Type.Optional(Type.String({ minLength: 1, maxLength: 2_000 })),
+    smiles: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
+    inchi: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
     molecularWeight: Type.Optional(Type.Number({ minimum: 0 })),
     atomCount: Type.Optional(Type.Integer({ minimum: 0 })),
     bondCount: Type.Optional(Type.Integer({ minimum: 0 })),
@@ -401,12 +382,10 @@ export const ScientificResultParams = Type.Object(
 export type ScientificResultParamsT = Static<typeof ScientificResultParams>;
 
 /**
- * Per-kind field ownership. `props` are the fields copied onto the card for that
- * kind (anything else the model sent is dropped); `required` drives a friendly
- * error before schema validation, whose union-wide messages are unreadable.
- *
- * `dataset-schema` and `molecule` have no single required field — each needs one
- * of several alternatives, which normalizeCard already checks and reports.
+ * Per-kind field ownership. `props` are copied onto the card (anything else is
+ * dropped); `required` drives a friendly error ahead of schema validation.
+ * `dataset-schema` and `molecule` list none — each needs one of several
+ * alternatives, which normalizeCard checks instead.
  */
 const KIND_SPEC = {
   table: {
@@ -462,11 +441,8 @@ const KIND_SPEC = {
 >;
 
 /**
- * Assemble the stored card from flat params, stamping the schema version.
- *
- * The version is server-supplied rather than model-supplied: it is not the
- * model's to choose, and asking for it was one of the things that broke —
- * `Type.Literal(1)` arrived as the string "1".
+ * Assemble the stored card from flat params. The schema version is stamped
+ * server-side: asking the model for it produced the string "1".
  */
 export function cardFromParams(params: ScientificResultParamsT): ScientificResultCard {
   const spec = KIND_SPEC[params.kind];
@@ -489,8 +465,8 @@ export function cardFromParams(params: ScientificResultParamsT): ScientificResul
     if (supplied[key] !== undefined) card[key] = supplied[key];
   }
 
-  // Validate against this kind's branch, not the union: union errors enumerate
-  // every branch at once and are useless to a model trying to correct itself.
+  // This kind's branch, not the union: union errors enumerate every branch and
+  // are useless to a model trying to correct itself.
   if (!Value.Check(spec.schema as typeof TableCardSchema, card)) {
     const detail = [...Value.Errors(spec.schema as typeof TableCardSchema, card)]
       .slice(0, 5)

--- a/server/src/api/system.ts
+++ b/server/src/api/system.ts
@@ -9,6 +9,10 @@ import {
   OPENAI_COMPATIBLE_BASE_URL,
   OPENAI_COMPATIBLE_CONFIGURED,
 } from "../config.ts";
+import {
+  contextWindowFromModelEntry,
+  noteOpenAICompatibleModels,
+} from "../agent/openai-compatible-context.ts";
 import { getSystemStats } from "../system-stats.ts";
 
 const GITHUB_REPO = "K-Dense-AI/k-dense-byok";
@@ -106,12 +110,16 @@ export async function registerSystemRoutes(app: FastifyInstance): Promise<void> 
       clearTimeout(t);
       if (!resp.ok) return { available: false, configured, models: [] };
       const data = (await resp.json()) as { data?: unknown };
+      const entries = Array.isArray(data.data) ? data.data : [];
+      // Cache reported context windows for buildOpenAICompatibleModel.
+      noteOpenAICompatibleModels(entries);
       // Deliberately lenient: take `id` off each entry and skip anything that
       // doesn't have one, so a single odd row can't blank out the whole list.
-      // Nothing beyond `id` is trusted — servers disagree on every other field.
+      // Beyond `id` and the context window, nothing is trusted — servers
+      // disagree on every other field.
       const seen = new Set<string>();
       const models = [];
-      for (const entry of Array.isArray(data.data) ? data.data : []) {
+      for (const entry of entries) {
         const id = (entry as { id?: unknown })?.id;
         if (typeof id !== "string" || !id.trim() || seen.has(id)) continue;
         seen.add(id);
@@ -120,7 +128,8 @@ export async function registerSystemRoutes(app: FastifyInstance): Promise<void> 
           label: id,
           provider: "OpenAI-Compatible",
           tier: "budget",
-          context_length: 0,
+          // 0 when unreported; the picker hides the badge rather than guess.
+          context_length: contextWindowFromModelEntry(entry) ?? 0,
           pricing: { prompt: 0, completion: 0 },
           modality: "text->text",
           description: `Local OpenAI-compatible model: ${id}`,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -87,14 +87,20 @@ export const OPENAI_COMPATIBLE_CONFIGURED = Boolean(
 );
 
 /**
- * Declared context window for openai-compatible (local llama.cpp / LM Studio /
- * vLLM) models. This must match the server's real context (llama.cpp `--ctx-size`)
- * so Pi leaves room for output tokens; a window smaller than the actual prompt
- * makes every run send ~0 output tokens. Defaults to 32K if unset.
+ * Fallback context window for openai-compatible models, consulted only when the
+ * server reported none of its own — see `agent/openai-compatible-context.ts`.
  */
 export const OPENAI_COMPATIBLE_CONTEXT_WINDOW = (() => {
-  const raw = Number(process.env.OPENAI_COMPATIBLE_CONTEXT_WINDOW);
-  return Number.isFinite(raw) && raw > 0 ? raw : 32_768;
+  const raw = process.env.OPENAI_COMPATIBLE_CONTEXT_WINDOW?.trim();
+  if (!raw) return 32_768;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  // Loud: silently reverting to 32K is the exact failure this setting prevents.
+  console.warn(
+    `[config] Ignoring OPENAI_COMPATIBLE_CONTEXT_WINDOW="${raw}" — expected a ` +
+      "positive number of tokens (e.g. 131072). Falling back to 32768.",
+  );
+  return 32_768;
 })();
 
 /** Whether Modal-style remote compute is configured (kept for /config parity). */

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -86,6 +86,17 @@ export const OPENAI_COMPATIBLE_CONFIGURED = Boolean(
   process.env.OPENAI_COMPATIBLE_BASE_URL?.trim(),
 );
 
+/**
+ * Declared context window for openai-compatible (local llama.cpp / LM Studio /
+ * vLLM) models. This must match the server's real context (llama.cpp `--ctx-size`)
+ * so Pi leaves room for output tokens; a window smaller than the actual prompt
+ * makes every run send ~0 output tokens. Defaults to 32K if unset.
+ */
+export const OPENAI_COMPATIBLE_CONTEXT_WINDOW = (() => {
+  const raw = Number(process.env.OPENAI_COMPATIBLE_CONTEXT_WINDOW);
+  return Number.isFinite(raw) && raw > 0 ? raw : 32_768;
+})();
+
 /** Whether Modal-style remote compute is configured (kept for /config parity). */
 export function modalConfigured(): boolean {
   return Boolean(process.env.MODAL_TOKEN_ID && process.env.MODAL_TOKEN_SECRET);

--- a/server/test/latex-assist.test.ts
+++ b/server/test/latex-assist.test.ts
@@ -20,6 +20,11 @@ function reset(): void {
 beforeEach(reset);
 afterAll(() => fs.rmSync(PROJECTS_ROOT, { recursive: true, force: true }));
 
+// Pinned so the suite does not inherit DEFAULT_MODEL_PROVIDER/DEFAULT_MODEL_ID
+// from the developer's shell: a local provider bills as free, which silently
+// turns every budget assertion into a no-op.
+const PAID_MODEL = "openrouter/anthropic/claude-opus-5";
+
 function fakeMessage(text: string): AssistantMessage {
   return {
     role: "assistant",
@@ -110,21 +115,20 @@ describe("runLatexAssist", () => {
   it("throws 402 when the project budget is exhausted", async () => {
     const p = createProject({ name: "Broke", spendLimitUsd: 0.000001 });
     updateProject(p.id, {});
+    const req = {
+      mode: "edit" as const,
+      fileName: "m.tex",
+      instruction: "x",
+      selection: "y",
+      model: PAID_MODEL,
+    };
     // Seed spend past the limit
     await withActiveProject(p.id, () =>
-      runLatexAssist(
-        { mode: "edit", fileName: "m.tex", instruction: "x", selection: "y" },
-        p.id,
-        async () => fakeMessage("ok"),
-      ),
+      runLatexAssist(req, p.id, async () => fakeMessage("ok")),
     );
     await expect(
       withActiveProject(p.id, () =>
-        runLatexAssist(
-          { mode: "edit", fileName: "m.tex", instruction: "x", selection: "y" },
-          p.id,
-          async () => fakeMessage("ok"),
-        ),
+        runLatexAssist(req, p.id, async () => fakeMessage("ok")),
       ),
     ).rejects.toMatchObject({ status: 402 });
   });

--- a/server/test/methods-draft.test.ts
+++ b/server/test/methods-draft.test.ts
@@ -26,6 +26,11 @@ const entryOf = (over: Partial<NotebookEntry> = {}): NotebookEntry => ({
   id: "e1", type: "method", title: "Ran PCA", timestamp: 1000, role: "agent", ...over,
 });
 
+// Pinned so the suite does not inherit DEFAULT_MODEL_PROVIDER/DEFAULT_MODEL_ID
+// from the developer's shell: a local provider bills as free, which silently
+// turns every budget assertion into a no-op.
+const PAID_MODEL = "openrouter/anthropic/claude-opus-5";
+
 function fakeMessage(text: string, over: Partial<AssistantMessage> = {}): AssistantMessage {
   return {
     role: "assistant",
@@ -176,7 +181,9 @@ describe("runMethodsDraft", () => {
     });
     await expect(
       withActiveProject(p.id, () =>
-        runMethodsDraft("s", p.id, {}, async () => fakeMessage("x")),
+        runMethodsDraft("s", p.id, { model: PAID_MODEL }, async () =>
+          fakeMessage("x"),
+        ),
       ),
     ).rejects.toMatchObject({ status: 402 });
   });

--- a/server/test/openai-compatible-context.test.ts
+++ b/server/test/openai-compatible-context.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   contextWindowFromModelEntry,
   noteOpenAICompatibleModels,
   openAICompatibleContextWindow,
   resetOpenAICompatibleContextWindows,
+  warmOpenAICompatibleContextWindows,
 } from "../src/agent/openai-compatible-context.ts";
 import { OPENAI_COMPATIBLE_CONTEXT_WINDOW } from "../src/config.ts";
 
@@ -85,5 +86,33 @@ describe("openAICompatibleContextWindow", () => {
     expect(() =>
       noteOpenAICompatibleModels([{ meta: { n_ctx: 8_192 } }, { id: "  " }, null]),
     ).not.toThrow();
+  });
+});
+
+describe("warmOpenAICompatibleContextWindows", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("populates the cache from a listing and coalesces concurrent calls", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ id: "big", meta: { n_ctx: 131_072 } }],
+        }),
+      } as Response;
+    }) as typeof fetch;
+
+    await Promise.all([
+      warmOpenAICompatibleContextWindows(),
+      warmOpenAICompatibleContextWindows(),
+    ]);
+    expect(calls).toBe(1);
+    expect(openAICompatibleContextWindow("big")).toBe(131_072);
   });
 });

--- a/server/test/openai-compatible-context.test.ts
+++ b/server/test/openai-compatible-context.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  contextWindowFromModelEntry,
+  noteOpenAICompatibleModels,
+  openAICompatibleContextWindow,
+  resetOpenAICompatibleContextWindows,
+} from "../src/agent/openai-compatible-context.ts";
+import { OPENAI_COMPATIBLE_CONTEXT_WINDOW } from "../src/config.ts";
+
+// Read from config rather than hardcoded: the fallback is env-configurable, and
+// these tests assert "falls back", not "falls back to 32768".
+const DEFAULT_WINDOW = OPENAI_COMPATIBLE_CONTEXT_WINDOW;
+
+beforeEach(() => resetOpenAICompatibleContextWindows());
+
+describe("contextWindowFromModelEntry", () => {
+  // Shape captured from a live `llama-server` router listing.
+  it("reads llama.cpp's served meta.n_ctx", () => {
+    expect(
+      contextWindowFromModelEntry({
+        id: "DeepSeek-V4-Flash:Q4_K_XL",
+        meta: { n_ctx: 131_072, n_ctx_train: 1_048_576, n_vocab: 129_280 },
+      }),
+    ).toBe(131_072);
+  });
+
+  // The whole point: n_ctx_train is the model's trained context, not what the
+  // server allocated. Using it would overcommit this model by 8x.
+  it("never falls back to n_ctx_train", () => {
+    expect(
+      contextWindowFromModelEntry({ id: "m", meta: { n_ctx_train: 1_048_576 } }),
+    ).toBeUndefined();
+  });
+
+  it("reads vLLM's max_model_len", () => {
+    expect(
+      contextWindowFromModelEntry({ id: "m", max_model_len: 65_536 }),
+    ).toBe(65_536);
+  });
+
+  it("returns undefined for models the server has not loaded", () => {
+    // A router lists every configured preset; only live ones carry `meta`.
+    expect(contextWindowFromModelEntry({ id: "Fara1.5-27B" })).toBeUndefined();
+  });
+
+  it("rejects malformed and out-of-range values", () => {
+    for (const meta of [
+      { n_ctx: 0 },
+      { n_ctx: -1 },
+      { n_ctx: 512 },
+      { n_ctx: "131072" },
+      { n_ctx: Number.NaN },
+      { n_ctx: 1e12 },
+    ]) {
+      expect(contextWindowFromModelEntry({ id: "m", meta })).toBeUndefined();
+    }
+    expect(contextWindowFromModelEntry(null)).toBeUndefined();
+    expect(contextWindowFromModelEntry("nope")).toBeUndefined();
+  });
+});
+
+describe("openAICompatibleContextWindow", () => {
+  it("defaults when nothing has been discovered", () => {
+    expect(openAICompatibleContextWindow("unknown")).toBe(DEFAULT_WINDOW);
+  });
+
+  it("returns per-model windows, defaulting only the unreported ones", () => {
+    noteOpenAICompatibleModels([
+      { id: "big", meta: { n_ctx: 131_072 } },
+      { id: "embed", meta: { n_ctx: 8_192 } },
+      { id: "unloaded" },
+    ]);
+    expect(openAICompatibleContextWindow("big")).toBe(131_072);
+    expect(openAICompatibleContextWindow("embed")).toBe(8_192);
+    expect(openAICompatibleContextWindow("unloaded")).toBe(DEFAULT_WINDOW);
+  });
+
+  it("keeps the last known window when a model stops reporting one", () => {
+    noteOpenAICompatibleModels([{ id: "big", meta: { n_ctx: 131_072 } }]);
+    noteOpenAICompatibleModels([{ id: "big" }]); // unloaded by the router
+    expect(openAICompatibleContextWindow("big")).toBe(131_072);
+  });
+
+  it("ignores entries without a usable id", () => {
+    expect(() =>
+      noteOpenAICompatibleModels([{ meta: { n_ctx: 8_192 } }, { id: "  " }, null]),
+    ).not.toThrow();
+  });
+});

--- a/server/test/scientific-result.test.ts
+++ b/server/test/scientific-result.test.ts
@@ -188,7 +188,7 @@ describe("scientific_result tool", () => {
         columns: [{ key: "a", label: "A" }],
         rows: [],
       }),
-    ).rejects.toThrow(/summary must not have more than 2000 characters/);
+    ).rejects.toThrow(/summary must not have more than 2048 characters/);
 
     // The byte cap still guards a payload that is large in aggregate while every
     // individual field stays within its own limit.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -26,9 +26,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // suppressHydrationWarning applies one level deep only, so both elements need
+  // it: next-themes writes `class` on <html>, and extensions such as Grammarly
+  // add attributes to <body> before React hydrates.
   return (
     <html lang="en" suppressHydrationWarning>
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -26,13 +26,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // suppressHydrationWarning applies one level deep only, so both elements need
-  // it: next-themes writes `class` on <html>, and extensions such as Grammarly
-  // add attributes to <body> before React hydrates.
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>


### PR DESCRIPTION
Fixes #38 

Runs Kady as a single container (backend :8000 + frontend :3000), and fixes two things that made local OpenAI-compatible servers unreliable.

Ports are localhost-only; projects and auth persist across rebuilds. LaTeX is optional via `--build-arg WITH_LATEX=0`. You still run your own model server — Kady just points at it.

We were declaring a hardcoded 32K for every local model. Too small and every run comes back empty; too large and the server truncates. Now we read the real window per model off the `/v1/models` listing the picker already fetches. `OPENAI_COMPATIBLE_CONTEXT_WINDOW` is now just a fallback for servers that don't report one, rather than something you have to get right by hand.

Also, scientific-result tool calls failed on llama.cpp with "failed to parse grammar". The trigger turned out to be a string bounded at exactly `maxLength: 2000` — 1999 and 2001 are both fine. Moved the bound to 2048, which keeps length validation intact for other providers.

## Testing

Full server suite green. Context detection verified against a live llama.cpp server with no env var set: models resolve to their actual served windows.