### PR TITLE
Add memorable Kady launcher and safe update command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,15 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+      - name: Run launcher unit tests
+        run: npm run test:launcher
+      - name: Run kady --check
+        if: runner.os != 'Windows'
+        run: ./kady --check
+      - name: Run kady.cmd --check
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: kady.cmd --check
       - name: Run start.sh --check
         if: runner.os != 'Windows'
         run: ./start.sh --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-K-Dense BYOK is a local AI research-assistant app ("Kady") that brings the user's own model credentials (API keys or supported subscriptions). It runs natively on macOS, Linux, and Windows. It is one repo with **two** runtime services started together by the cross-platform launcher `start.mjs` (wrapped by `./start.sh` on macOS/Linux and `start.cmd` on Windows):
+K-Dense BYOK is a local AI research-assistant app ("Kady") that brings the user's own model credentials (API keys or supported subscriptions). It runs natively on macOS, Linux, and Windows. It is one repo with **two** runtime services started together by the cross-platform launcher `start.mjs` (exposed as `./kady` on macOS/Linux and `kady.cmd` on Windows; `start.sh` / `start.cmd` remain compatibility aliases):
 
 | Service | Port | Code |
 |---|---|---|
@@ -38,8 +38,10 @@ npm run test                # vitest
 Full app (both services):
 
 ```bash
-./start.sh                  # installs deps, seeds skills, starts backend + frontend
-start.cmd                   # same, on Windows (both wrap `node start.mjs`)
+./kady                      # installs deps, seeds skills, starts backend + frontend
+kady.cmd                    # same, on Windows
+./kady update               # safely fast-forwards the current checkout and exits
+./start.sh / start.cmd      # compatibility aliases (all wrap `node start.mjs`)
 ```
 
 ## Architecture: how a turn flows

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Open a terminal (on a Mac: press `Cmd+Space`, type "Terminal", press Enter) and 
 git clone https://github.com/K-Dense-AI/k-dense-byok.git
 cd k-dense-byok
 cp .env.example .env    # optional: add an OpenRouter key or other settings
-./start.sh
+./kady
 ```
 
 On Windows (press `Win`, type "PowerShell" or "Terminal", press Enter):
@@ -118,12 +118,14 @@ On Windows (press `Win`, type "PowerShell" or "Terminal", press Enter):
 git clone https://github.com/K-Dense-AI/k-dense-byok.git
 cd k-dense-byok
 copy .env.example .env    # optional: add an OpenRouter key or other settings
-.\start.cmd
+.\kady.cmd
 ```
 
 In plain terms: the first two lines download the app and step into its folder; the third creates an optional local settings file; the last starts the app. If you use a supported subscription instead of OpenRouter, connect it in **Settings → Model providers** once Kady opens.
 
 The first start installs everything automatically (it takes a few minutes); then your browser opens to **http://localhost:3000** — that address is your own computer, not a website. Press **Ctrl+C** in the terminal to stop the app. You can connect subscriptions under **Model providers** and add or change keys under **API keys** anytime — no restart needed.
+
+Later, start Kady with `./kady` (macOS/Linux) or `.\kady.cmd` (Windows). To update the checkout safely to its configured upstream, run `./kady update` or `.\kady.cmd update`; it refuses to pull over tracked local changes.
 
 That's it. Create a project, drop in your data, and ask Kady for what you want — for example: *"Run a differential expression analysis on counts.csv comparing treated vs control, and plot a volcano plot."*
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ This page explains how K-Dense BYOK runs on your computer. You do not need to re
 
 ## The two services
 
-The start script (`start.sh` on macOS/Linux, `start.cmd` on Windows — both thin wrappers around the cross-platform `start.mjs` launcher) launches two local services that work together:
+The launcher (`kady` on macOS/Linux, `kady.cmd` on Windows; `start.sh` / `start.cmd` remain compatibility aliases around the same cross-platform `start.mjs`) launches two local services that work together:
 
 | Service | Port | What it does |
 |---------|------|--------------|
@@ -70,7 +70,7 @@ cost ledgers remain durable.
 
 ## First-run setup
 
-The first time you start the app (`./start.sh` or `start.cmd`), it will automatically:
+The first time you start the app (`./kady` or `kady.cmd`), it will automatically:
 
 - Install backend dependencies (`server/`) and frontend dependencies (`web/`)
 - Install [uv](https://docs.astral.sh/uv/) if missing - the Python manager Kady uses to run analyses in each sandbox
@@ -84,7 +84,8 @@ Subsequent starts are much faster.
 ```
 k-dense-byok/
 ├── start.mjs             ← The launcher that starts everything (cross-platform)
-├── start.sh / start.cmd  ← Thin macOS-Linux / Windows wrappers around it
+├── kady / kady.cmd      ← Memorable macOS-Linux / Windows entry points
+├── start.sh / start.cmd ← Compatibility wrappers around the same launcher
 ├── .env                  ← Optional API keys and overrides (gitignored)
 ├── server/               ← Backend (TypeScript, Pi SDK)
 │   └── src/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,11 +78,11 @@ OAuth tokens are kept outside the repository and all projects. By default Pi sto
 ## 5. Start the app
 
 ```bash
-./start.sh     # macOS / Linux
-.\start.cmd    # Windows
+./kady         # macOS / Linux
+.\kady.cmd     # Windows
 ```
 
-(Both are thin wrappers around the same cross-platform launcher — `node start.mjs` works anywhere too.)
+(`start.sh` / `start.cmd` remain supported for compatibility; all wrappers use the same cross-platform `start.mjs` launcher.)
 
 The first run takes a few minutes. The script automatically:
 
@@ -109,20 +109,19 @@ The `.env` file also lists keys for specific scientific databases (NCBI, Materia
 
 ## Updating to a new version
 
-From the project folder:
+From the project folder, use the built-in updater:
 
 ```bash
-git pull
-./start.sh     # macOS / Linux
-.\start.cmd    # Windows
+./kady update         # macOS / Linux
+.\kady.cmd update    # Windows
 ```
 
-The startup script picks up any new packages and skills automatically.
+It fast-forwards the current branch from its configured upstream and exits. It refuses to run over tracked local changes, a detached HEAD, or a branch without an upstream, so it never stashes, resets, or merges local work automatically. Start Kady normally afterwards; the launcher picks up any new packages and skills automatically.
 
 ## Troubleshooting
 
-- **`./start.sh: Permission denied`** (macOS/Linux) — run `chmod +x start.sh` once, then try again.
-- **Windows says "Windows protected your PC"** when double-clicking `start.cmd` — click *More info → Run anyway*, or run it from a terminal instead (`.\start.cmd`).
+- **`./kady: Permission denied`** (macOS/Linux) — run `chmod +x kady start.sh` once, then try again.
+- **Windows says "Windows protected your PC"** when double-clicking `kady.cmd` — click *More info → Run anyway*, or run it from a terminal instead (`.\kady.cmd`).
 - **Browser doesn't open** — go to [http://localhost:3000](http://localhost:3000) manually.
 - **"No API key" warning** — make sure your key is in `.env` (the file is `.env`, not `.env.example`), paste it in **Settings → API keys** (OpenRouter or NVIDIA), start Ollama, or connect a supported subscription in **Settings → Model providers**.
 - **Port already in use** — the startup script clears leftover Kady processes automatically and names any other program holding port 3000 or 8000. Quit the program it names (or set `KADY_PORT` in `.env` to move the backend) and start the app again.

--- a/kady
+++ b/kady
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Memorable launcher alias. start.sh remains supported for compatibility.
+set -e
+cd "$(dirname "$0")"
+exec ./start.sh "$@"

--- a/kady.cmd
+++ b/kady.cmd
@@ -1,0 +1,6 @@
+@echo off
+rem Memorable launcher alias. start.cmd remains supported for compatibility.
+setlocal
+cd /d "%~dp0"
+call start.cmd %*
+exit /b %errorlevel%

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "start": "node start.mjs",
-    "check": "node start.mjs --check"
+    "check": "node start.mjs --check",
+    "test:launcher": "node --test scripts/update-checkout.test.mjs"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/update-checkout.mjs
+++ b/scripts/update-checkout.mjs
@@ -1,0 +1,92 @@
+import { spawnSync } from "node:child_process";
+
+export class CheckoutUpdateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CheckoutUpdateError";
+  }
+}
+
+function git(repoRoot, args) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    windowsHide: true,
+  });
+  if (result.error) {
+    throw new CheckoutUpdateError(`Could not run git: ${result.error.message}`);
+  }
+  return result;
+}
+
+function gitText(repoRoot, args, failureMessage) {
+  const result = git(repoRoot, args);
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || "").trim();
+    throw new CheckoutUpdateError(
+      detail ? `${failureMessage}\n${detail}` : failureMessage,
+    );
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * Safely fast-forward the current checkout from its configured upstream.
+ *
+ * We deliberately do not stash, reset, or merge. Automatic updating is only
+ * safe when tracked files are clean and `git pull --ff-only` can advance the
+ * current branch without rewriting local work.
+ */
+export function updateCheckout({ repoRoot, log = () => {} }) {
+  const inside = gitText(
+    repoRoot,
+    ["rev-parse", "--is-inside-work-tree"],
+    "This copy of Kady is not a Git checkout, so it cannot update itself.",
+  );
+  if (inside !== "true") {
+    throw new CheckoutUpdateError(
+      "This copy of Kady is not a Git checkout, so it cannot update itself.",
+    );
+  }
+
+  const branch = gitText(
+    repoRoot,
+    ["symbolic-ref", "--quiet", "--short", "HEAD"],
+    "Automatic update is unavailable from a detached HEAD. Check out a branch first.",
+  );
+
+  const upstream = gitText(
+    repoRoot,
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    `Branch '${branch}' has no upstream branch. Configure one before using automatic update.`,
+  );
+
+  const dirty = gitText(
+    repoRoot,
+    ["status", "--porcelain", "--untracked-files=no"],
+    "Could not inspect the Git working tree before updating.",
+  );
+  if (dirty) {
+    throw new CheckoutUpdateError(
+      "Kady has local changes in tracked files. Commit or discard them before updating; " +
+        "the updater will never stash or overwrite your work automatically.",
+    );
+  }
+
+  const before = gitText(repoRoot, ["rev-parse", "HEAD"], "Could not read the current revision.");
+  log(`Updating ${branch} from ${upstream}...`);
+
+  const pulled = git(repoRoot, ["pull", "--ff-only"]);
+  const stdout = pulled.stdout.trim();
+  const stderr = pulled.stderr.trim();
+  if (stdout) log(stdout);
+  if (pulled.status !== 0) {
+    throw new CheckoutUpdateError(
+      "Git could not fast-forward this checkout. No local history was rewritten." +
+        (stderr ? `\n${stderr}` : ""),
+    );
+  }
+
+  const after = gitText(repoRoot, ["rev-parse", "HEAD"], "Could not read the updated revision.");
+  return { branch, upstream, before, after, updated: before !== after };
+}

--- a/scripts/update-checkout.test.mjs
+++ b/scripts/update-checkout.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { updateCheckout } from "./update-checkout.mjs";
+
+function git(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8", windowsHide: true });
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(" ")} failed\n${result.stdout}\n${result.stderr}`,
+  );
+  return result.stdout.trim();
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kady-update-"));
+  const remote = path.join(root, "remote.git");
+  const seed = path.join(root, "seed");
+  const checkout = path.join(root, "checkout");
+
+  git(root, ["init", "--bare", "-b", "main", remote]);
+  fs.mkdirSync(seed);
+  git(seed, ["init", "-b", "main"]);
+  git(seed, ["config", "user.name", "Kady test"]);
+  git(seed, ["config", "user.email", "kady-test@example.invalid"]);
+  fs.writeFileSync(path.join(seed, "version.txt"), "one\n");
+  git(seed, ["add", "version.txt"]);
+  git(seed, ["commit", "-m", "initial"]);
+  git(seed, ["remote", "add", "origin", remote]);
+  git(seed, ["push", "-u", "origin", "main"]);
+  git(root, ["clone", remote, checkout]);
+
+  return {
+    root,
+    seed,
+    checkout,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function publishNext(seed, value = "two\n") {
+  fs.writeFileSync(path.join(seed, "version.txt"), value);
+  git(seed, ["add", "version.txt"]);
+  git(seed, ["commit", "-m", "next"]);
+  git(seed, ["push"]);
+}
+
+test("fast-forwards a clean checkout from its configured upstream", () => {
+  const f = fixture();
+  try {
+    publishNext(f.seed);
+    const messages = [];
+    const result = updateCheckout({ repoRoot: f.checkout, log: (line) => messages.push(line) });
+
+    assert.equal(result.updated, true);
+    assert.equal(result.branch, "main");
+    assert.equal(result.upstream, "origin/main");
+    assert.equal(fs.readFileSync(path.join(f.checkout, "version.txt"), "utf-8"), "two\n");
+    assert.ok(messages.some((line) => line.includes("Updating main from origin/main")));
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("does not touch tracked local changes", () => {
+  const f = fixture();
+  try {
+    publishNext(f.seed);
+    fs.writeFileSync(path.join(f.checkout, "version.txt"), "my local edit\n");
+
+    assert.throws(
+      () => updateCheckout({ repoRoot: f.checkout }),
+      /local changes in tracked files/,
+    );
+    assert.equal(fs.readFileSync(path.join(f.checkout, "version.txt"), "utf-8"), "my local edit\n");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("refuses branches without a configured upstream", () => {
+  const f = fixture();
+  try {
+    git(f.checkout, ["checkout", "-b", "local-only"]);
+    assert.throws(
+      () => updateCheckout({ repoRoot: f.checkout }),
+      /has no upstream branch/,
+    );
+  } finally {
+    f.cleanup();
+  }
+});

--- a/start.mjs
+++ b/start.mjs
@@ -2,8 +2,12 @@
 /**
  * Kady launcher — cross-platform port of the original start.sh, used on
  * macOS, Linux, and Windows alike. Zero dependencies (it runs before any
- * npm install). The platform wrappers (start.sh / start.cmd) only make sure
- * Node itself exists, then exec this file.
+ * npm install). The platform wrappers (kady / kady.cmd, plus the legacy
+ * start.sh / start.cmd aliases) only make sure Node itself exists, then exec
+ * this file.
+ *
+ * Commands:
+ *   update        safely fast-forward this Git checkout and exit
  *
  * Flags:
  *   --check       report dependencies/environment and exit (no installs, no services)
@@ -15,12 +19,14 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { applyEnvFile } from "./env-file.mjs";
+import { updateCheckout } from "./scripts/update-checkout.mjs";
 
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 const isWin = process.platform === "win32";
 const flags = {
   check: process.argv.includes("--check"),
   noBrowser: process.argv.includes("--no-browser"),
+  update: process.argv.slice(2)[0] === "update",
 };
 
 // Legacy conhost garbles unicode; Windows Terminal (WT_SESSION) renders it fine.
@@ -477,12 +483,32 @@ function openBrowser(url) {
 // ---- main --------------------------------------------------------------------
 
 log("============================================");
-log("  Kady — Starting up");
+log(`  Kady — ${flags.update ? "Updating" : "Starting up"}`);
 log("============================================");
 log("");
-log("Checking dependencies...");
+log(flags.update ? "Checking update prerequisites..." : "Checking dependencies...");
 
 checkNode();
+
+if (flags.update) {
+  if (!has("git")) {
+    fail(`  ${sym.err} git is required for automatic updates.`);
+  }
+  try {
+    const result = updateCheckout({ repoRoot, log });
+    log("");
+    if (result.updated) {
+      log(`  ${sym.ok} Kady updated successfully.`);
+      log(`    ${result.before.slice(0, 8)} ${sym.arrow} ${result.after.slice(0, 8)}`);
+    } else {
+      log(`  ${sym.ok} Kady is already up to date.`);
+    }
+  } catch (error) {
+    fail(`\n  ${sym.err} Update stopped safely.\n    ${error instanceof Error ? error.message.replaceAll("\n", "\n    ") : String(error)}`);
+  }
+  process.exit(0);
+}
+
 ensureUv();
 checkGit();
 checkPython();


### PR DESCRIPTION
Fixes #37

This adds a memorable `kady` / `kady.cmd` entry point while keeping `start.sh` / `start.cmd` fully compatible.

It also adds `kady update`, which safely fast-forwards the current checkout from its configured upstream. The updater refuses tracked local changes, detached HEADs, branches without an upstream, and non-fast-forward updates instead of stashing, resetting, or merging automatically.

Tests:
- `npm run test:launcher`
- `./kady --check`
- `./start.sh --check`
- updater integration tests cover fast-forward, dirty tracked files, and missing upstreams

The launcher smoke workflow now runs the updater unit tests and checks the new entry point on macOS, Linux, and Windows.