### PR TITLE
Add Docker and Compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Git and editor state
+.git
+.gitignore
+.github
+.vscode
+.idea
+.DS_Store
+
+# Never copy local credentials or user data into an image
+.env
+.env.*
+!.env.example
+projects
+
+# Dependencies and build output are recreated in the image
+**/node_modules
+**/.next
+**/dist
+**/coverage
+**/.turbo
+
+# Local/runtime noise
+**/*.log
+**/.venv
+**/__pycache__
+**/.pytest_cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tags
+        id: image
+        shell: bash
+        run: |
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
+          VERSION="$(node -p "require('./server/package.json').version")"
+          {
+            echo "name=$IMAGE"
+            echo "tags<<EOF"
+            echo "$IMAGE:latest"
+            echo "$IMAGE:v$VERSION"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.image.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+COPY server/package.json server/package-lock.json ./server/
+RUN npm ci --prefix server --no-audit --no-fund
+
+COPY web/package.json web/package-lock.json ./web/
+RUN npm ci --prefix web --no-audit --no-fund
+
+COPY . .
+
+ARG NEXT_PUBLIC_ADK_API_URL=http://localhost:8000
+ENV NEXT_PUBLIC_ADK_API_URL=${NEXT_PUBLIC_ADK_API_URL}
+RUN npm --prefix web run build
+
+FROM node:22-bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/K-Dense-AI/k-dense-byok" \
+      org.opencontainers.image.licenses="MIT"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash ca-certificates curl git python3 tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+
+ENV NODE_ENV=production \
+    HOME=/home/node \
+    KADY_HOST=0.0.0.0 \
+    KADY_PORT=8000 \
+    KADY_FRONTEND_PORT=3000 \
+    KADY_PROJECTS_ROOT=/data/projects \
+    KADY_PI_AGENT_DIR=/home/node/.kady/pi-agent
+
+WORKDIR /app
+COPY --from=build --chown=node:node /app /app
+
+RUN mkdir -p /data/projects /home/node/.kady \
+    && chown -R node:node /data/projects /home/node/.kady \
+    && chmod +x /app/scripts/docker-entrypoint.sh
+
+USER node
+
+VOLUME ["/data/projects", "/home/node/.kady"]
+EXPOSE 3000 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=3m --retries=5 \
+  CMD curl -fsS http://127.0.0.1:8000/health >/dev/null \
+   && curl -fsS http://127.0.0.1:3000/ >/dev/null \
+   || exit 1
+
+ENTRYPOINT ["tini", "--", "/app/scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ The first start installs everything automatically (it takes a few minutes); then
 
 That's it. Create a project, drop in your data, and ask Kady for what you want — for example: *"Run a differential expression analysis on counts.csv comparing treated vs control, and plot a volcano plot."*
 
+### Docker
+
+If you already have Docker, the same app can run in one container:
+
+```bash
+git clone https://github.com/K-Dense-AI/k-dense-byok.git
+cd k-dense-byok
+docker compose up -d
+```
+
+Open **http://localhost:3000**. Project files stay in `./projects`, while provider logins and Kady state use a persistent Docker volume. See [Docker](./docs/docker.md) for the pre-built image, local-model networking, updates, and custom ports.
+
 ➡️ **Step-by-step details, optional API keys, and troubleshooting:** [Installation guide](./docs/installation.md)
 ➡️ **Your first session and everyday features:** [Basic usage](./docs/basic-usage.md)
 ➡️ **Prefer to watch first?** [Tutorial videos](#tutorial-videos)
@@ -154,6 +166,7 @@ All guides live in the [`docs/`](./docs) folder:
 |-------|----------------|
 | [Codebase summary](./docs/codebase-summary.md) | One-page overview of what K-Dense BYOK is, what it can do, and why it matters |
 | [Installation](./docs/installation.md) | Full setup walkthrough, subscriptions, optional API keys, updating, troubleshooting |
+| [Docker](./docs/docker.md) | Run Kady with Docker Compose or the pre-built GHCR image |
 | [Basic usage](./docs/basic-usage.md) | First session, chat tabs, files, workflows, databases, costs, tips |
 | [File previews](./docs/file-previews.md) | Every scientific format Kady can render — structures, spectra, imaging, arrays, and more |
 | [Living Lab Notebook](./docs/lab-notebook.md) | Real-time record of Kady's work — structured entries, export, and PDF |

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,28 @@
+services:
+  kady:
+    image: ghcr.io/k-dense-ai/k-dense-byok:latest
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_ADK_API_URL: ${NEXT_PUBLIC_ADK_API_URL:-http://localhost:8000}
+    ports:
+      - "${KADY_FRONTEND_PORT:-3000}:3000"
+      - "8000:8000"
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      KADY_HOST: 0.0.0.0
+      KADY_PORT: 8000
+      KADY_FRONTEND_PORT: 3000
+      KADY_PROJECTS_ROOT: /data/projects
+      KADY_PI_AGENT_DIR: /home/node/.kady/pi-agent
+    volumes:
+      - ./projects:/data/projects
+      - kady-state:/home/node/.kady
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+volumes:
+  kady-state:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,92 @@
+# Docker
+
+K-Dense BYOK can run as a single Docker container containing both the Next.js UI and TypeScript backend. The image includes Node.js, git, Python, and `uv`; scientific Python environments and the skills catalogue are prepared on first start just like the native launcher.
+
+## Docker Compose
+
+From the repository root:
+
+```bash
+cp .env.example .env   # optional; add provider keys if you use them
+docker compose up -d
+```
+
+Open [http://localhost:3000](http://localhost:3000). The backend is published on port 8000 for the browser UI.
+
+Compose uses the pre-built `ghcr.io/k-dense-ai/k-dense-byok:latest` image when available. To build the current checkout instead:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+Project data is bind-mounted to `./projects`, so deleting or replacing the container does not delete your work. Provider OAuth state, settings, and the shared skills cache live in the named `kady-state` volume.
+
+Useful commands:
+
+```bash
+docker compose logs -f
+docker compose restart
+docker compose pull && docker compose up -d
+docker compose down
+```
+
+`docker compose down` keeps both `./projects` and the `kady-state` volume. Add `-v` only when you intentionally want to delete the Docker-managed Kady state, including stored provider logins.
+
+## Docker run
+
+The published image can also be run without Compose:
+
+```bash
+docker run --rm -it \
+  --name kady \
+  -p 3000:3000 \
+  -p 8000:8000 \
+  --env-file .env \
+  -e KADY_HOST=0.0.0.0 \
+  -e KADY_PORT=8000 \
+  -e KADY_FRONTEND_PORT=3000 \
+  -e KADY_PROJECTS_ROOT=/data/projects \
+  -e KADY_PI_AGENT_DIR=/home/node/.kady/pi-agent \
+  -v "$PWD/projects:/data/projects" \
+  -v kady-state:/home/node/.kady \
+  ghcr.io/k-dense-ai/k-dense-byok:latest
+```
+
+Omit `--env-file .env` when the file does not exist and configure model access later in Settings.
+
+## Local model servers
+
+A container has its own loopback interface. If Ollama, LM Studio, or another local model server runs on the host, use `host.docker.internal` instead of `localhost` in `.env. Docker Compose already adds the Linux host-gateway mapping as well as using Docker Desktop's built-in mapping:
+
+```bash
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+OPENAI_COMPATIBLE_BASE_URL=http://host.docker.internal:1234
+```
+
+For a direct `docker run` on Linux, add:
+
+```bash
+--add-host=host.docker.internal:host-gateway
+```
+
+## Ports and remote access
+
+The container listens internally on ports 3000 and 8000. With Compose you can move the UI to another host port without rebuilding:
+
+```bash
+KADY_FRONTEND_PORT=3100 docker compose up -d
+```
+
+The pre-built frontend targets `http://localhost:8000`, so Compose keeps the backend published on host port 8000. If you need a different public backend URL, including access from another machine, build the image with that URL and publish the matching backend port. For example:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_ADK_API_URL=http://localhost:8100 \
+  -t kady-custom .
+docker run --rm -p 3000:3000 -p 8100:8000 kady-custom
+```
+
+## Image publishing
+
+The repository Docker workflow builds both `linux/amd64` and `linux/arm64`. Pull requests validate the image build. Commits merged to `main` publish two GHCR tags: `latest` and the version from `server/package.json`, for example `v0.9.14`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,8 @@ This guide walks you through installing K-Dense BYOK from scratch. No coding exp
 
 Everything else (Python tooling, packages, scientific skills) is installed automatically the first time you start the app.
 
+If you prefer Docker, Node.js and the other host requirements are not needed. Install Docker Desktop or Docker Engine with Compose and follow the [Docker guide](./docker.md).
+
 > **Optional — LaTeX PDF reports:** if you want Kady's LaTeX editor to compile PDFs, install a TeX distribution: [MacTeX](https://www.tug.org/mactex/) (macOS), TeX Live (Linux), or [MiKTeX](https://miktex.org/) / [TeX Live](https://www.tug.org/texlive/) (Windows). Not needed for normal use.
 
 ## 2. Choose model access

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+backend_pid=""
+frontend_pid=""
+
+shutdown() {
+  trap - INT TERM EXIT
+  [[ -n "$backend_pid" ]] && kill -TERM "$backend_pid" 2>/dev/null || true
+  [[ -n "$frontend_pid" ]] && kill -TERM "$frontend_pid" 2>/dev/null || true
+  [[ -n "$backend_pid" ]] && wait "$backend_pid" 2>/dev/null || true
+  [[ -n "$frontend_pid" ]] && wait "$frontend_pid" 2>/dev/null || true
+}
+trap shutdown INT TERM EXIT
+
+mkdir -p "${KADY_PROJECTS_ROOT:-/data/projects}" "${KADY_PI_AGENT_DIR:-$HOME/.kady/pi-agent}"
+
+# Keep first-run setup identical to the native launcher: create the default
+# project, seed skills, and prepare the uv-managed Python environments.
+npm --prefix /app/server run prep --silent
+
+npm --prefix /app/server run start &
+backend_pid=$!
+
+npm --prefix /app/web run start -- --hostname 0.0.0.0 --port "${KADY_FRONTEND_PORT:-3000}" &
+frontend_pid=$!
+
+# Exit the container if either long-running service exits. The trap then stops
+# the sibling cleanly so Docker can restart the whole application as one unit.
+wait -n "$backend_pid" "$frontend_pid"
+status=$?
+exit "$status"


### PR DESCRIPTION
Closes #38

## What changed

- add a production Docker image for the Next.js frontend and TypeScript backend
- run first-start project, skills, and Python environment preparation inside the container
- run the application as the unprivileged `node` user with a real container health check
- add Docker Compose with persistent project data and provider/settings state
- support host-local Ollama and other OpenAI-compatible servers through `host.docker.internal`
- add a GitHub Actions build that validates and publishes `linux/amd64` and `linux/arm64` images to GHCR on `main`
- document Compose, direct `docker run`, updates, persistence, local-model networking, and custom builds

## Validation

- `docker buildx build --check .`
- `docker compose config`
- native ARM64 image build
- live ARM64 container smoke test: frontend 200, backend `/health` 200, Docker health `healthy`, non-root UID 1000
- verified project bind-mounted data survives container replacement
- Linux AMD64 image build under emulation
- server typecheck
- server tests: 604 passed, 29 skipped
- web tests: 529 passed
- Next.js production build passes inside both Docker architecture builds
